### PR TITLE
Accept the debug flag

### DIFF
--- a/src/main/java/net/runelite/launcher/Launcher.java
+++ b/src/main/java/net/runelite/launcher/Launcher.java
@@ -63,6 +63,7 @@ public class Launcher
 		parser.accepts("version").withRequiredArg();
 		parser.accepts("clientargs").withRequiredArg();
 		parser.accepts("nojvm");
+		parser.accepts("debug");
 		OptionSet options = parser.parse(args);
 
 		LauncherFrame frame = new LauncherFrame();

--- a/src/main/java/net/runelite/launcher/Launcher.java
+++ b/src/main/java/net/runelite/launcher/Launcher.java
@@ -114,6 +114,9 @@ public class Launcher
 			}
 		}
 
+		frame.setVisible(false);
+		frame.dispose();
+
 		String clientArgs = getArgs(options);
 
 		// packr doesn't let us specify command line arguments
@@ -125,9 +128,6 @@ public class Launcher
 		{
 			JvmLauncher.launch(bootstrap, results, clientArgs, options);
 		}
-
-		frame.setVisible(false);
-		frame.dispose();
 	}
 
 	private static Bootstrap getBootstrap() throws Exception


### PR DESCRIPTION
Re-add the debug option as it was lost in c07bc32a758a0216a19ff46c1b06596db015428e
Also dispose of the frame before launching the client, as it created an infinite loop in debug mode which would prevent the frame from being disposed.

Also fixes #2  