### PR TITLE
Ask for 2mb stack, not 2mb heap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
 								<argument>--vmargs</argument>
 								<argument>Drunelite.launcher.nojvm=true</argument>
 								<argument>Xmx512m</argument>
-								<argument>Xms2m</argument>
+								<argument>Xss2m</argument>
 								<argument>Dsun.java2d.noddraw=false</argument>
 								<argument>XX:CompileThreshold=1500</argument>
 								<argument>Xincgc</argument>


### PR DESCRIPTION
I guess when we were copying this from Jagex's config we typoed Xss, which changes the maximum stack size, to Xms which changes minimum heap size. Apparently the GC tries to keep it's heap as close to minimum as possible when Xms is specified, so it was running almost constantly on release.

Fixes [runelite#1290](https://github.com/runelite/runelite/issues/1290)