### PR TITLE
Add configurable hardware acceleration param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
-/nbproject/
 target
-.idea
+nbactions.xml
+nb-configuration.xml
+/nbproject/
+project.properties
+*.iml
+.idea/
+.project
+.settings/
+.classpath

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,6 @@
 								<argument>Drunelite.launcher.nojvm=true</argument>
 								<argument>Xmx512m</argument>
 								<argument>Xss2m</argument>
-								<argument>Dsun.java2d.noddraw=false</argument>
 								<argument>XX:CompileThreshold=1500</argument>
 								<argument>Xincgc</argument>
 								<argument>XX:+UseConcMarkSweepGC</argument>
@@ -319,7 +318,6 @@
 								<argument>Drunelite.launcher.nojvm=true</argument>
 								<argument>Xmx512m</argument>
 								<argument>Xss2m</argument>
-								<argument>Dsun.java2d.noddraw=false</argument>
 								<argument>XX:CompileThreshold=1500</argument>
 								<argument>Xincgc</argument>
 								<argument>XX:+UseConcMarkSweepGC</argument>

--- a/src/main/java/net/runelite/launcher/HardwareAccelerationMode.java
+++ b/src/main/java/net/runelite/launcher/HardwareAccelerationMode.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2018, Tomas Slusny <slusnucky@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.launcher;
+
+import java.awt.GraphicsEnvironment;
+import java.util.ArrayList;
+import java.util.List;
+
+public enum HardwareAccelerationMode
+{
+	OFF,
+	DIRECTDRAW,
+	OPENGL;
+
+	/**
+	 * Enables OpenGL or DirectDraw hardware rendering on systems that support it.
+	 * See https://docs.oracle.com/javase/8/docs/technotes/guides/2d/flags.html for reference
+	 */
+	public void enable()
+	{
+		System.setProperty("sun.java2d.noddraw", "true");
+		System.setProperty("sun.java2d.opengl", "false");
+
+		if (this == OFF)
+		{
+			return;
+		}
+
+		final boolean accelerated = GraphicsEnvironment
+				.getLocalGraphicsEnvironment()
+				.getDefaultScreenDevice()
+				.getDefaultConfiguration()
+				.getImageCapabilities().isAccelerated();
+
+		if (accelerated)
+		{
+			switch (this)
+			{
+				case DIRECTDRAW:
+					System.setProperty("sun.java2d.noddraw", "false");
+					break;
+				case OPENGL:
+					System.setProperty("sun.java2d.opengl", "true");
+					break;
+			}
+		}
+	}
+
+	/**
+	 * Convert hardware acceleration mode to list of params to be passed to JVM
+	 * @return list of params
+	 */
+	public List<String> toParams()
+	{
+		final List<String> params = new ArrayList<>();
+
+		final boolean accelerated = GraphicsEnvironment
+				.getLocalGraphicsEnvironment()
+				.getDefaultScreenDevice()
+				.getDefaultConfiguration()
+				.getImageCapabilities().isAccelerated();
+
+		if (accelerated)
+		{
+			switch (this)
+			{
+				case DIRECTDRAW:
+					params.add("-Dsun.java2d.noddraw=false");
+					params.add("-Dsun.java2d.opengl=false");
+					break;
+				case OPENGL:
+					params.add("-Dsun.java2d.noddraw=true");
+					params.add("-Dsun.java2d.opengl=true");
+					break;
+			}
+		}
+		else
+		{
+			params.add("-Dsun.java2d.noddraw=true");
+			params.add("-Dsun.java2d.opengl=false");
+		}
+
+		return params;
+	}
+}

--- a/src/main/java/net/runelite/launcher/JvmLauncher.java
+++ b/src/main/java/net/runelite/launcher/JvmLauncher.java
@@ -69,7 +69,7 @@ class JvmLauncher
 		return javaPath.toAbsolutePath().toString();
 	}
 
-	public static void launch(Bootstrap bootstrap, List<ArtifactResult> results, String clientArgs, OptionSet options) throws Exception
+	public static void launch(Bootstrap bootstrap, List<ArtifactResult> results, String clientArgs, OptionSet options, HardwareAccelerationMode mode) throws Exception
 	{
 		StringBuilder classPath = new StringBuilder();
 		for (ArtifactResult ar : results)
@@ -113,6 +113,7 @@ class JvmLauncher
 			jvmArguments = bootstrap.getClientJvm9Arguments();
 		}
 		arguments.addAll(Arrays.asList(jvmArguments));
+		arguments.addAll(mode.toParams());
 
 		arguments.add(CLIENT_MAIN_CLASS);
 		if (clientArgs != null)

--- a/src/main/java/net/runelite/launcher/Launcher.java
+++ b/src/main/java/net/runelite/launcher/Launcher.java
@@ -37,6 +37,7 @@ import java.security.cert.CertificateFactory;
 import java.util.List;
 import java.util.jar.JarFile;
 import javax.swing.UIManager;
+import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import net.runelite.launcher.beans.Bootstrap;
@@ -65,7 +66,20 @@ public class Launcher
 		parser.accepts("clientargs").withRequiredArg();
 		parser.accepts("nojvm");
 		parser.accepts("debug");
+
+		// Create typed argument for the hardware acceleration mode (default to open gl for cross-platform)
+		final ArgumentAcceptingOptionSpec<HardwareAccelerationMode> mode = parser.accepts("mode")
+				.withRequiredArg()
+				.ofType(HardwareAccelerationMode.class)
+				.defaultsTo(HardwareAccelerationMode.OPENGL);
+
 		OptionSet options = parser.parse(args);
+
+		// Get hardware acceleration mode
+		final HardwareAccelerationMode hardwareAccelerationMode = options.valueOf(mode);
+
+		// Setup hardware acceleration
+		hardwareAccelerationMode.enable();
 
 		try
 		{
@@ -139,7 +153,7 @@ public class Launcher
 		}
 		else
 		{
-			JvmLauncher.launch(bootstrap, results, clientArgs, options);
+			JvmLauncher.launch(bootstrap, results, clientArgs, options, hardwareAccelerationMode);
 		}
 	}
 


### PR DESCRIPTION
- Add --mode param with OFF, OPENGL and DIRECTDRAW params for
configuring the acceleartion for respective modes (default to OPENGL for
cross-platform)
- Update .gitignore to be same as RuneLite repo one

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>