### PR TITLE
Always prefer IPv4 over IPv6

### DIFF
--- a/src/main/java/net/runelite/launcher/Launcher.java
+++ b/src/main/java/net/runelite/launcher/Launcher.java
@@ -77,6 +77,9 @@ public class Launcher
 
 		OptionSet options = parser.parse(args);
 
+		// Always use IPv4 over IPv6
+		System.setProperty("java.net.preferIPv4Stack", "true");
+
 		// Setup logger
 		LOGS_DIR.mkdirs();
 		MDC.put("logFileName", LOGS_FILE_NAME.getAbsolutePath());


### PR DESCRIPTION
Without this, resolving Maven artifacts on some network configuration
will fail and launcher will be stuck on 0%.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

https://gyazo.com/9f397724521c4d84ac72d98f3a343692