### PR TITLE
Remove faulty hw acceleration check

### DIFF
--- a/src/main/java/net/runelite/launcher/HardwareAccelerationMode.java
+++ b/src/main/java/net/runelite/launcher/HardwareAccelerationMode.java
@@ -24,7 +24,6 @@
  */
 package net.runelite.launcher;
 
-import java.awt.GraphicsEnvironment;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -50,29 +49,14 @@ public enum HardwareAccelerationMode
 			return;
 		}
 
-		final boolean accelerated = GraphicsEnvironment
-				.getLocalGraphicsEnvironment()
-				.getDefaultScreenDevice()
-				.getDefaultConfiguration()
-				.getImageCapabilities().isAccelerated();
-
-		if (accelerated)
+		switch (this)
 		{
-			switch (this)
-			{
-				case DIRECTDRAW:
-					log.info("Setting hardware acceleration to DirectDraw");
-					System.setProperty("sun.java2d.noddraw", "false");
-					break;
-				case OPENGL:
-					log.info("Setting hardware acceleration to OpenGL");
-					System.setProperty("sun.java2d.opengl", "true");
-					break;
-			}
-		}
-		else
-		{
-			log.warn("Hardware acceleration is not supported.");
+			case DIRECTDRAW:
+				System.setProperty("sun.java2d.noddraw", "false");
+				break;
+			case OPENGL:
+				System.setProperty("sun.java2d.opengl", "true");
+				break;
 		}
 	}
 
@@ -84,33 +68,19 @@ public enum HardwareAccelerationMode
 	{
 		final List<String> params = new ArrayList<>();
 
-		final boolean accelerated = GraphicsEnvironment
-				.getLocalGraphicsEnvironment()
-				.getDefaultScreenDevice()
-				.getDefaultConfiguration()
-				.getImageCapabilities().isAccelerated();
-
-		if (accelerated)
+		switch (this)
 		{
-			switch (this)
-			{
-				case DIRECTDRAW:
-					log.info("Setting hardware acceleration to DirectDraw");
-					params.add("-Dsun.java2d.noddraw=false");
-					params.add("-Dsun.java2d.opengl=false");
-					break;
-				case OPENGL:
-					log.info("Setting hardware acceleration to OpenGL");
-					params.add("-Dsun.java2d.noddraw=true");
-					params.add("-Dsun.java2d.opengl=true");
-					break;
-			}
-		}
-		else
-		{
-			log.warn("Hardware acceleration is not supported.");
-			params.add("-Dsun.java2d.noddraw=true");
-			params.add("-Dsun.java2d.opengl=false");
+			case DIRECTDRAW:
+				params.add("-Dsun.java2d.noddraw=false");
+				params.add("-Dsun.java2d.opengl=false");
+				break;
+			case OPENGL:
+				params.add("-Dsun.java2d.noddraw=true");
+				params.add("-Dsun.java2d.opengl=true");
+				break;
+			case OFF:
+				params.add("-Dsun.java2d.noddraw=true");
+				params.add("-Dsun.java2d.opengl=false");
 		}
 
 		return params;

--- a/src/main/java/net/runelite/launcher/Launcher.java
+++ b/src/main/java/net/runelite/launcher/Launcher.java
@@ -73,7 +73,7 @@ public class Launcher
 		final ArgumentAcceptingOptionSpec<HardwareAccelerationMode> mode = parser.accepts("mode")
 				.withRequiredArg()
 				.ofType(HardwareAccelerationMode.class)
-				.defaultsTo(HardwareAccelerationMode.OPENGL);
+				.defaultsTo(HardwareAccelerationMode.OFF);
 
 		OptionSet options = parser.parse(args);
 
@@ -91,6 +91,7 @@ public class Launcher
 		final HardwareAccelerationMode hardwareAccelerationMode = options.valueOf(mode);
 
 		// Setup hardware acceleration
+		log.info("Setting hardware acceleration to {}", hardwareAccelerationMode);
 		hardwareAccelerationMode.enable();
 
 		try


### PR DESCRIPTION
The hardware acceleration check was always false unless someone had
global JVM arguments modified (or was modyfing launcher JVM arguments)
because the check was actually checking if hardware acceleration is
already enabled and not if it is supported.
To solve this, default hardware acceleration mode to OFF, but leave the
possibility to easily change it to OPENGL or DIRECTDRAW to tune
performance.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>