### PR TITLE
Add a --jvmargs option

### DIFF
--- a/src/main/java/net/runelite/launcher/Launcher.java
+++ b/src/main/java/net/runelite/launcher/Launcher.java
@@ -76,6 +76,7 @@ import javax.swing.SwingUtilities;
 import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.launcher.beans.Artifact;
 import net.runelite.launcher.beans.Bootstrap;
@@ -102,6 +103,7 @@ public class Launcher
 		parser.accepts("nojvm");
 		parser.accepts("debug");
 		parser.accepts("nodiff");
+		OptionSpec<String> jvmargs = parser.accepts("jvmargs").withRequiredArg();
 
 		HardwareAccelerationMode defaultMode;
 		switch (OS.getOs())
@@ -173,6 +175,9 @@ public class Launcher
 
 			// Stream launcher version
 			extraJvmParams.add("-D" + LauncherProperties.getVersionKey() + "=" + LauncherProperties.getVersion());
+
+			// Add user specified options
+			extraJvmParams.addAll(jvmargs.values(options));
 
 			// Set all JVM params
 			setJvmParams(extraJvmParams);


### PR DESCRIPTION
~This is mostly for Linux users with Java 9+, to force hidpi ui scaling. This technically should work for any OS. I tried playing around with `-Dsun.java2d.dpiaware=true` (and false), so it could be automatic, but that did not seem to work (so it could be possibly be added to the bootstrap.json).~

Decided to make this generic. Allows the user to pass extra jvm args to the client, such as `-j -Dsun.java2d.uiScale=2` to force hidpi. If it's better to give the user less control over the jvm, I can change it back to just having a `--hidpi` option.