### PR TITLE
Add logging of JVM properties to debug

### DIFF
--- a/src/main/java/net/runelite/launcher/HardwareAccelerationMode.java
+++ b/src/main/java/net/runelite/launcher/HardwareAccelerationMode.java
@@ -36,27 +36,8 @@ public enum HardwareAccelerationMode
 	OPENGL;
 
 	/**
-	 * Enables OpenGL or DirectDraw hardware rendering on systems that support it.
+	 * Gets list of JVM properties to enable Hardware Acceleration for this mode.
 	 * See https://docs.oracle.com/javase/8/docs/technotes/guides/2d/flags.html for reference
-	 */
-	public void enable()
-	{
-		System.setProperty("sun.java2d.noddraw", "true");
-		System.setProperty("sun.java2d.opengl", "false");
-
-		switch (this)
-		{
-			case DIRECTDRAW:
-				System.setProperty("sun.java2d.noddraw", "false");
-				break;
-			case OPENGL:
-				System.setProperty("sun.java2d.opengl", "true");
-				break;
-		}
-	}
-
-	/**
-	 * Convert hardware acceleration mode to list of params to be passed to JVM
 	 * @return list of params
 	 */
 	public List<String> toParams()

--- a/src/main/java/net/runelite/launcher/Launcher.java
+++ b/src/main/java/net/runelite/launcher/Launcher.java
@@ -50,8 +50,10 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.stream.Collectors;
 import javax.swing.UIManager;
 import joptsimple.ArgumentAcceptingOptionSpec;
@@ -115,6 +117,21 @@ public class Launcher
 		{
 			final Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 			logger.setLevel(Level.DEBUG);
+		}
+
+		// Print out system info
+		if (log.isDebugEnabled())
+		{
+			log.debug("Java Environment:");
+			final Properties p = System.getProperties();
+			final Enumeration keys = p.keys();
+
+			while (keys.hasMoreElements())
+			{
+				final String key = (String) keys.nextElement();
+				final String value = (String) p.get(key);
+				log.debug("  {}: {}", key, value);
+			}
 		}
 
 		// Get hardware acceleration mode


### PR DESCRIPTION
To help with determining possible future issues, add printing out of
Java environment properties to debug.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Depends on #24