### PR TITLE
Added support for deleting old launcher files

### DIFF
--- a/src/main/java/net/runelite/launcher/Launcher.java
+++ b/src/main/java/net/runelite/launcher/Launcher.java
@@ -54,6 +54,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.swing.UIManager;
 import joptsimple.ArgumentAcceptingOptionSpec;
@@ -180,6 +181,9 @@ public class Launcher
 		PackrConfig.updateLauncherArgs(bootstrap);
 
 		REPO_DIR.mkdirs();
+
+		// Clean out old artifacts from the repository
+		clean(bootstrap.getArtifacts());
 
 		try
 		{
@@ -331,6 +335,35 @@ public class Launcher
 					bytes += i;
 					fout.write(buffer, 0, i);
 					frame.progress(artifact.getName(), bytes, artifact.getSize());
+				}
+			}
+		}
+	}
+
+	private static void clean(Artifact[] artifacts)
+	{
+		File[] existingFiles = REPO_DIR.listFiles();
+
+		if (existingFiles == null)
+		{
+			return;
+		}
+
+		Set<String> artifactNames = Arrays.stream(artifacts)
+			.map(Artifact::getName)
+			.collect(Collectors.toSet());
+
+		for (File file : existingFiles)
+		{
+			if (file.isFile() && !artifactNames.contains(file.getName()))
+			{
+				if (file.delete())
+				{
+					log.debug("Deleted old artifact {}", file);
+				}
+				else
+				{
+					log.warn("Unable to delete old artifact {}", file);
 				}
 			}
 		}


### PR DESCRIPTION
For users who use the launcher to play Runelite, a directory is created in RUNELITE_DIR called 'repository2'. Every weekly update, there is a version update, so each of those files is re-generated with a new version number.

![image](https://user-images.githubusercontent.com/41882962/50066718-76fec200-018b-11e9-85fd-d57a19f0a45f.png)

What this means is about every week, another 4 MB of storage is added to the user's hard drive for no apparent reason. 

I propose a change such that the old client version files are deleted on startup, as this could save a good amount of storage for Runelite users.

In a hypothetical scenario where the Runelite client updates once every week: 
52 weeks * 4 MB = **208 MB** saved per year! - Now let's say you save 200 MB a year for 40,000 users - I'd say that's significant!

![image](https://user-images.githubusercontent.com/41882962/50066824-f7bdbe00-018b-11e9-9453-2fe6af7b3659.png)

The solution simply adds all the artifact names (from the bootstrap.json file) to a HashSet, then compares that to the files listed from `REPO_DIR` using `contains`; anything not found with this check will be deleted, thusly.

