### PR TITLE
JDK 9+ support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.20</version>
+			<version>1.16.22</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency> <!-- hack to lock check packr -->
@@ -187,7 +187,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -604,7 +604,7 @@
 						<lock>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
-							<hash>SHA-256:c5178b18caaa1a15e17b99ba5e4023d2de2ebc18b58cde0f5a04ca4b31c10e6d</hash>
+							<hash>SHA-256:9cadc430e156950d7deb6f226d74c5e2aacb6cf21b7ef60638e6af4369e7bb8d</hash>
 						</lock>
 						<lock>
 							<groupId>com.github.libgdx</groupId>

--- a/src/main/java/net/runelite/launcher/ReflectionLauncher.java
+++ b/src/main/java/net/runelite/launcher/ReflectionLauncher.java
@@ -25,6 +25,7 @@
 package net.runelite.launcher;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -47,7 +48,20 @@ class ReflectionLauncher
 			jarUrls[i++] = file.toURI().toURL();
 		}
 
-		URLClassLoader loader = new URLClassLoader(jarUrls, null);
+		//Needed for support on JDK9+
+		ClassLoader parent;
+
+		try
+		{
+			Method getPlatformClassLoaderMethod =  ClassLoader.class.getMethod("getPlatformClassLoader");
+			parent = (ClassLoader) getPlatformClassLoaderMethod.invoke(null);
+		}
+		catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ex)
+		{
+			parent = null;
+		}
+
+		URLClassLoader loader = new URLClassLoader(jarUrls, parent);
 
 		UIManager.put("ClassLoader", loader); // hack for Substance
 		Thread thread = new Thread()


### PR DESCRIPTION
This PR allows the game to build on JDK8, JDK9, and JDK11 and to launch on these Java versions when using the `--nojvm` flag.  I have not tested the game on any of these Java versions.

Note: to run on JDK11 you will need to add `-Dhttps.protocols=TLSv1.2,TLSv1.1,TLSv1` to the java command line.  I may submit a future PR to make this unnecessary.