### PR TITLE
Allow automatic graphics switching on mac

### DIFF
--- a/src/main/resources/Info.plist
+++ b/src/main/resources/Info.plist
@@ -24,5 +24,7 @@
   <integer>1</integer>
   <key>NSHighResolutionCapable</key>
   <true/>
+  <key>NSSupportsAutomaticGraphicsSwitching</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
This PR adds a new key value pair to the `info.plist` file used in the mac launcher. Documentation on the key added is available [here](https://developer.apple.com/documentation/bundleresources/information_property_list/nssupportsautomaticgraphicsswitching). Adding this key, with its value set to `true`, allows runelite to take advantage of the Intel integrated graphics available on some MacBook Pros. Using integrated graphics should provide improved power consumption and thermals on these machines. Without this change, these laptops will always turn on their dedicated AMD/NVIDIA cards. 

I'll update this PR a bit later with some before/after readings on my temps. Using Activity Monitor I've already confirmed that with this change my AMD card does not activate, as expected.

Edit: I've included some temperature results below. The effects of this change are most profound when playing in resizable mode. All temperatures are in Fahrenheit. These were runs were done without any frame rate limitations and with my laptop (2017 with AMD 560) on a well ventilated surface.

This image is after 20 min fishing at barbarian village with the client using only the intel graphics. The last six of those minutes were in resizable mode.
<img width="270" alt="pasted graphic 1" src="https://user-images.githubusercontent.com/16804460/51435824-9d55c880-1c35-11e9-98dd-058adc5d61a0.png">


This image is after 20 min fishing at barbarian village WITHOUT the changes to `info.plist`, the last six of which were in resizable mode (GPU utilization increased when switching to resizable mode)
<img width="272" alt="pasted graphic 4" src="https://user-images.githubusercontent.com/16804460/51435815-6bdcfd00-1c35-11e9-9741-6bf3b27054b7.png">

The bottom of my laptop definitely seems cooler running with the intel graphics, and the fans remained largely idle, unlike with the client using the discrete GPU, where the fans actually spun up to the point that they were noticeable.