### PR TITLE
Redirect JVM crash logs to ~/.runelite/logs

### DIFF
--- a/src/main/java/net/runelite/launcher/Launcher.java
+++ b/src/main/java/net/runelite/launcher/Launcher.java
@@ -71,6 +71,7 @@ public class Launcher
 	private static final File RUNELITE_DIR = new File(System.getProperty("user.home"), ".runelite");
 	private static final File LOGS_DIR = new File(RUNELITE_DIR, "logs");
 	private static final File REPO_DIR = new File(RUNELITE_DIR, "repository2");
+	private static final File CRASH_FILES = new File(LOGS_DIR, "jvm_crash_pid_%p.log");
 	private static final String CLIENT_BOOTSTRAP_URL = "https://static.runelite.net/bootstrap.json";
 	private static final String CLIENT_BOOTSTRAP_SHA256_URL = "https://static.runelite.net/bootstrap.json.sha256";
 	private static final LauncherProperties PROPERTIES = new LauncherProperties();
@@ -149,6 +150,10 @@ public class Launcher
 		// Set all JVM params
 		setJvmParams(extraJvmParams);
 
+		// Set hs_err_pid location (do this after setJvmParams because it can't be set at runtime)
+		log.debug("Setting JVM crash log location to {}", CRASH_FILES);
+		extraJvmParams.add("-XX:ErrorFile=" + CRASH_FILES.getAbsolutePath());
+
 		try
 		{
 			UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
@@ -175,7 +180,7 @@ public class Launcher
 		}
 
 		// update packr vmargs
-		PackrConfig.updateLauncherArgs(bootstrap);
+		PackrConfig.updateLauncherArgs(bootstrap, extraJvmParams);
 
 		REPO_DIR.mkdirs();
 

--- a/src/main/java/net/runelite/launcher/PackrConfig.java
+++ b/src/main/java/net/runelite/launcher/PackrConfig.java
@@ -32,6 +32,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.launcher.beans.Bootstrap;
@@ -40,7 +43,7 @@ import net.runelite.launcher.beans.Bootstrap;
 public class PackrConfig
 {
 	// Update the packr vmargs
-	public static void updateLauncherArgs(Bootstrap bootstrap)
+	public static void updateLauncherArgs(Bootstrap bootstrap, Collection<String> extraJvmArgs)
 	{
 		File configFile = new File("config.json").getAbsoluteFile();
 
@@ -63,12 +66,16 @@ public class PackrConfig
 			return;
 		}
 
-		String[] args = getArgs(bootstrap);
-		if (args == null || args.length == 0)
+		String[] argsArr = getArgs(bootstrap);
+		if (argsArr == null || argsArr.length == 0)
 		{
 			log.warn("Launcher args are empty");
 			return;
 		}
+
+		// Insert JVM arguments to config.json because some of them require restart
+		List<String> args = Arrays.asList(argsArr);
+		args.addAll(extraJvmArgs);
 
 		config.put("vmArgs", args);
 


### PR DESCRIPTION
By modifying jvm params before starting application (thanks to packr and
it's config.json) this redirects all jvm crash logs to
~/.runelite/logs/jvm_crash_pid_<process_id>.log. Also works with
launcher that spawns new JVM because it can also set JVM args
beforehand. Do not works with AppImage, because there is no way to
dynamically update config.json, and AppImage is also using
ReflectionLauncher.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>