### PR TITLE
Support Dark Mode for the native window chrome on macOS

### DIFF
--- a/packr/Info.plist
+++ b/packr/Info.plist
@@ -26,5 +26,7 @@
   <true/>
   <key>NSSupportsAutomaticGraphicsSwitching</key>
   <true/>
+  <key>NSRequiresAquaSystemAppearance</key>
+  <false/>
 </dict>
 </plist>


### PR DESCRIPTION
macOS 10.14 added a dark mode for the native window chrome, but applications need to declare that they support it for it to be used. This can be done through `NSRequiresAquaSystemAppearance` in the `Info.plist` file. Whether the light or dark theme gets used is automatically decided based on the user's settings.

<img src="https://user-images.githubusercontent.com/3169418/62825419-8cf24480-bbab-11e9-97b5-edfdb90b5b82.png" width="250"> <img src="https://user-images.githubusercontent.com/3169418/62825422-924f8f00-bbab-11e9-9c3f-79549705144a.png" width="250">
