### PR TITLE
SplashScreen: Ceiling download total

### DIFF
--- a/src/main/java/net/runelite/launcher/SplashScreen.java
+++ b/src/main/java/net/runelite/launcher/SplashScreen.java
@@ -209,8 +209,9 @@ public class SplashScreen extends JFrame implements ActionListener
 		String progress;
 		if (mib)
 		{
-			final double MiB = 1024 * 1042;
-			progress = String.format("%.1f / %.1f MiB", done / MiB, total / MiB);
+			final double MiB = 1024 * 1024;
+			final double CEIL = 1.d / 10.d;
+			progress = String.format("%.1f / %.1f MiB", done / MiB, (total / MiB) + CEIL);
 		}
 		else
 		{


### PR DESCRIPTION
Otherwise it says `0.0 / 0.0 MiB` when downloading small files