### PR TITLE
Update Maven repository links to use HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 	<repositories>
 		<repository>
 			<id>central</id>
-			<url>http://repo1.maven.org/maven2</url>
+			<url>https://repo1.maven.org/maven2</url>
 		</repository>
 		<repository>
 			<id>runelite</id>
@@ -68,7 +68,7 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>central</id>
-			<url>http://repo1.maven.org/maven2</url>
+			<url>https://repo1.maven.org/maven2</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>runelite</id>


### PR DESCRIPTION
Maven demands all access to its repositories are now done over HTTPS, so the pom file needs to reflect this, or the launcher won't build if there isn't already cached packages downloaded.