### PR TITLE
Use runelite/packr and sign macOS output

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "packr/packr"]
-	path = packr/packr
-	url = https://github.com/libgdx/packr

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -4,6 +4,7 @@ set -e
 
 JDK_VER="11.0.4"
 JDK_BUILD="11"
+PACKR_VERSION="runelite-1.0"
 
 if ! [ -f OpenJDK11U-jre_x64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz ] ; then
     curl -Lo OpenJDK11U-jre_x64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz \
@@ -20,7 +21,14 @@ if ! [ -d linux-jdk ] ; then
     mv jdk-11.0.4+11-jre linux-jdk/jre
 fi
 
-java -jar packr.jar \
+if ! [ -f packr_${PACKR_VERSION}.jar ] ; then
+    curl -Lo packr_${PACKR_VERSION}.jar \
+        https://github.com/runelite/packr/releases/download/${PACKR_VERSION}/packr.jar
+fi
+
+echo "18b7cbaab4c3f9ea556f621ca42fbd0dc745a4d11e2a08f496e2c3196580cd53  packr_${PACKR_VERSION}.jar" | sha256sum -c
+
+java -jar packr_${PACKR_VERSION}.jar \
     --platform \
     linux64 \
     --jdk \

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -6,6 +6,10 @@ JDK_VER="11.0.4"
 JDK_BUILD="11"
 PACKR_VERSION="runelite-1.0"
 
+SIGNING_IDENTITY="Developer ID Application"
+ALTOOL_USER="user@icloud.com"
+ALTOOL_PASS="@keychain:altool-password"
+
 if ! [ -f OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz ] ; then
     curl -Lo OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz \
         https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz
@@ -62,6 +66,12 @@ pushd native-osx/RuneLite.app
 chmod g+x,o+x Contents/MacOS/RuneLite
 popd
 
+codesign -f -s "${SIGNING_IDENTITY}" --entitlements osx/signing.entitlements --options runtime native-osx/RuneLite.app || true
+
 # create-dmg exits with an error code due to no code signing, but is still okay
 # note we use Adam-/create-dmg as upstream does not support UDBZ
-create-dmg --format UDBZ native-osx/RuneLite.app || true
+create-dmg --format UDBZ native-osx/RuneLite.app native-osx/ || true
+
+mv native-osx/RuneLite\ *.dmg native-osx/RuneLite.dmg
+
+xcrun altool --notarize-app --username "${ALTOOL_USER}" --password "${ALTOOL_PASS}" --primary-bundle-id runelite --file native-osx/RuneLite.dmg || true

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -4,6 +4,7 @@ set -e
 
 JDK_VER="11.0.4"
 JDK_BUILD="11"
+PACKR_VERSION="runelite-1.0"
 
 if ! [ -f OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz ] ; then
     curl -Lo OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz \
@@ -25,7 +26,14 @@ if ! [ -d osx-jdk ] ; then
     popd
 fi
 
-java -jar packr.jar \
+if ! [ -f packr_${PACKR_VERSION}.jar ] ; then
+    curl -Lo packr_${PACKR_VERSION}.jar \
+        https://github.com/runelite/packr/releases/download/${PACKR_VERSION}/packr.jar
+fi
+
+echo "18b7cbaab4c3f9ea556f621ca42fbd0dc745a4d11e2a08f496e2c3196580cd53  packr_${PACKR_VERSION}.jar" | shasum -c
+
+java -jar packr_${PACKR_VERSION}.jar \
     --platform \
     mac \
     --icon \

--- a/build-win32.sh
+++ b/build-win32.sh
@@ -4,6 +4,7 @@ set -e
 
 JDK_VER="11.0.4"
 JDK_BUILD="11"
+PACKR_VERSION="runelite-1.0"
 
 if ! [ -f OpenJDK11U-jre_x86-32_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip ] ; then
     curl -Lo OpenJDK11U-jre_x86-32_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip \
@@ -20,7 +21,14 @@ if ! [ -d win32-jdk ] ; then
     mv jdk-11.0.4+11-jre win32-jdk/jre
 fi
 
-java -jar packr.jar \
+if ! [ -f packr_${PACKR_VERSION}.jar ] ; then
+    curl -Lo packr_${PACKR_VERSION}.jar \
+        https://github.com/runelite/packr/releases/download/${PACKR_VERSION}/packr.jar
+fi
+
+echo "18b7cbaab4c3f9ea556f621ca42fbd0dc745a4d11e2a08f496e2c3196580cd53  packr_${PACKR_VERSION}.jar" | sha256sum -c
+
+java -jar packr_${PACKR_VERSION}.jar \
     --platform \
     windows32 \
     --jdk \

--- a/build-win64.sh
+++ b/build-win64.sh
@@ -4,6 +4,7 @@ set -e
 
 JDK_VER="11.0.4"
 JDK_BUILD="11"
+PACKR_VERSION="runelite-1.0"
 
 if ! [ -f OpenJDK11U-jre_x64_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip ] ; then
     curl -Lo OpenJDK11U-jre_x64_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip \
@@ -20,7 +21,14 @@ if ! [ -d win64-jdk ] ; then
     mv jdk-11.0.4+11-jre win64-jdk/jre
 fi
 
-java -jar packr.jar \
+if ! [ -f packr_${PACKR_VERSION}.jar ] ; then
+    curl -Lo packr_${PACKR_VERSION}.jar \
+        https://github.com/runelite/packr/releases/download/${PACKR_VERSION}/packr.jar
+fi
+
+echo "18b7cbaab4c3f9ea556f621ca42fbd0dc745a4d11e2a08f496e2c3196580cd53  packr_${PACKR_VERSION}.jar" | sha256sum -c
+
+java -jar packr_${PACKR_VERSION}.jar \
     --platform \
     windows64 \
     --jdk \

--- a/osx/signing.entitlements
+++ b/osx/signing.entitlements
@@ -1,0 +1,6 @@
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Changes the build scripts to use our packr build from https://github.com/runelite/packr/releases instead of libgdx/packr so https://github.com/runelite/packr/commit/e285e558d2b26839b591cc974ca868280ab9173c is applied. 

Also adds code in the macOS build script for signing the app and notarizing the .dmg.