### PR TITLE
Wrap Desktop.Open() to fix buttons not working on Linux

### DIFF
--- a/src/main/java/net/runelite/launcher/FatalErrorDialog.java
+++ b/src/main/java/net/runelite/launcher/FatalErrorDialog.java
@@ -140,11 +140,13 @@ public class FatalErrorDialog extends JDialog
 
 		addButton("Open logs folder", () ->
 		{
-
-			if (! LinkBrowser.open(Launcher.LOGS_DIR.toString()))
+			new Thread()
 			{
-				log.warn("Unable to open logs");
-			}
+				public void run()
+				{
+					LinkBrowser.open(Launcher.LOGS_DIR.toString());
+				}
+			}.start();
 		});
 		addButton("Get help on Discord", () -> LinkBrowser.browse(LauncherProperties.getDiscordInvite()));
 		addButton("Troubleshooting steps", () -> LinkBrowser.browse(LauncherProperties.getTroubleshootingLink()));

--- a/src/main/java/net/runelite/launcher/FatalErrorDialog.java
+++ b/src/main/java/net/runelite/launcher/FatalErrorDialog.java
@@ -140,13 +140,7 @@ public class FatalErrorDialog extends JDialog
 
 		addButton("Open logs folder", () ->
 		{
-			new Thread()
-			{
-				public void run()
-				{
-					LinkBrowser.open(Launcher.LOGS_DIR.toString());
-				}
-			}.start();
+			LinkBrowser.open(Launcher.LOGS_DIR.toString());
 		});
 		addButton("Get help on Discord", () -> LinkBrowser.browse(LauncherProperties.getDiscordInvite()));
 		addButton("Troubleshooting steps", () -> LinkBrowser.browse(LauncherProperties.getTroubleshootingLink()));

--- a/src/main/java/net/runelite/launcher/FatalErrorDialog.java
+++ b/src/main/java/net/runelite/launcher/FatalErrorDialog.java
@@ -143,11 +143,24 @@ public class FatalErrorDialog extends JDialog
 		{
 			try
 			{
+			if ("Linux".equals(System.getProperty("os.name")))
+			{
+				final Process exec = Runtime.getRuntime().exec(new String[]{"xdg-open", Launcher.LOGS_DIR.toString()});
+				exec.waitFor();
+				if ( exec.exitValue() == 0 )
+				{
+					return;
+				}
+			}
 				Desktop.getDesktop().open(Launcher.LOGS_DIR);
 			}
 			catch (IOException e)
 			{
 				log.warn("Unable to open logs", e);
+			}
+			catch (InterruptedException e)
+			{
+				log.warn("Interrupted during xdg-open", e);
 			}
 		});
 		addButton("Get help on Discord", () -> LinkBrowser.browse(LauncherProperties.getDiscordInvite()));

--- a/src/main/java/net/runelite/launcher/FatalErrorDialog.java
+++ b/src/main/java/net/runelite/launcher/FatalErrorDialog.java
@@ -28,7 +28,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
-import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.event.WindowAdapter;
@@ -141,26 +140,10 @@ public class FatalErrorDialog extends JDialog
 
 		addButton("Open logs folder", () ->
 		{
-			try
+
+			if (! LinkBrowser.open(Launcher.LOGS_DIR.toString()))
 			{
-			if ("Linux".equals(System.getProperty("os.name")))
-			{
-				final Process exec = Runtime.getRuntime().exec(new String[]{"xdg-open", Launcher.LOGS_DIR.toString()});
-				exec.waitFor();
-				if ( exec.exitValue() == 0 )
-				{
-					return;
-				}
-			}
-				Desktop.getDesktop().open(Launcher.LOGS_DIR);
-			}
-			catch (IOException e)
-			{
-				log.warn("Unable to open logs", e);
-			}
-			catch (InterruptedException e)
-			{
-				log.warn("Interrupted during xdg-open", e);
+				log.warn("Unable to open logs");
 			}
 		});
 		addButton("Get help on Discord", () -> LinkBrowser.browse(LauncherProperties.getDiscordInvite()));

--- a/src/main/java/net/runelite/launcher/LinkBrowser.java
+++ b/src/main/java/net/runelite/launcher/LinkBrowser.java
@@ -29,6 +29,7 @@ import java.awt.Desktop;
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
 import java.io.IOException;
+import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import javax.swing.JOptionPane;
@@ -36,12 +37,13 @@ import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Utility class used for browser navigation
+ * Utility class used for web and file browser navigation
  */
 @Slf4j
 public class LinkBrowser
 {
 	private static boolean shouldAttemptXdg = OS.getOs() == OS.OSType.Linux;
+	private static boolean isSnapClient = ! Strings.isNullOrEmpty(System.getenv("SNAP"));
 
 	/**
 	 * Tries to navigate to specified URL in browser. In case operation fails, displays message box with message
@@ -69,6 +71,48 @@ public class LinkBrowser
 		}
 
 		showMessageBox("Unable to open link. Press 'OK' and the link will be copied to your clipboard.", url);
+		return false;
+	}
+
+	/**
+	 * Tries to open a directory in the OS native file manager.
+	 * @param directory directory to open
+	 * @return true if operation was correctly sent to the OS, not necessarily true for whether the OS actually opened the directory (E.G, Snap)
+	 */
+	public static boolean open(final String directory)
+	{
+		if (Strings.isNullOrEmpty(directory))
+		{
+			return false;
+		}
+
+		//Snap specific workaround to prevent thread blocking on attempts to open folders.
+		if (isSnapClient)
+		{
+			try
+			{
+				Runtime.getRuntime().exec(new String[]{"xdg-open", directory});
+				log.debug("Attempted to open directory with snap workaround to {}", directory);
+			}
+			catch (IOException e)
+			{
+				log.warn("Snap specific error handling xdg-open {}", directory, e);
+			}
+			return true;
+		}
+
+		if (attemptDesktopOpen(directory))
+		{
+			log.debug("Opened directory through Desktop#open to {}", directory);
+			return true;
+		}
+
+		if (shouldAttemptXdg && attemptXdgOpen(directory))
+		{
+			log.debug("Opened directory through xdg-open to {}", directory);
+			return true;
+		}
+
 		return false;
 	}
 
@@ -127,6 +171,32 @@ public class LinkBrowser
 		}
 	}
 
+	private static boolean attemptDesktopOpen(String directory)
+	{
+		if (!Desktop.isDesktopSupported())
+		{
+			return false;
+		}
+
+		final Desktop desktop = Desktop.getDesktop();
+
+		if (!desktop.isSupported(Desktop.Action.OPEN))
+		{
+			return false;
+		}
+
+		try
+		{
+			desktop.open(new File(directory));
+			return true;
+		}
+		catch (IOException ex)
+		{
+			log.warn("Failed to open Desktop#open {}", directory, ex);
+			return false;
+		}
+	}
+
 	/**
 	 * Open swing message box with specified message and copy data to clipboard
 	 * @param message message to show
@@ -144,5 +214,5 @@ public class LinkBrowser
 				Toolkit.getDefaultToolkit().getSystemClipboard().setContents(stringSelection, null);
 			}
 		});
-	}
+	}		
 }

--- a/src/main/java/net/runelite/launcher/LinkBrowser.java
+++ b/src/main/java/net/runelite/launcher/LinkBrowser.java
@@ -71,6 +71,7 @@ public class LinkBrowser
 			}
 			log.warn("LinkBrowser.browse() could not open {}", url);
 		}).start();
+		showMessageBox("Unable to open link. Press 'OK' and the link will be copied to your clipboard.", url);
 	}
 
 	/**

--- a/src/main/java/net/runelite/launcher/LinkBrowser.java
+++ b/src/main/java/net/runelite/launcher/LinkBrowser.java
@@ -69,6 +69,7 @@ public class LinkBrowser
 				log.debug("Opened directory through xdg-open to {}", url);
 				return;
 			}
+
 			log.warn("LinkBrowser.browse() could not open {}", url);
 			showMessageBox("Unable to open link. Press 'OK' and the link will be copied to your clipboard.", url);
 		}).start();
@@ -99,6 +100,7 @@ public class LinkBrowser
 				log.debug("Opened directory through xdg-open to {}", directory);
 				return;
 			}
+
 			log.warn("LinkBrowser.open() could not open {}", directory);
 			showMessageBox("Unable to open folder. Press 'OK' and the folder directory will be copied to your clipboard.", directory);
 		}).start();

--- a/src/main/java/net/runelite/launcher/LinkBrowser.java
+++ b/src/main/java/net/runelite/launcher/LinkBrowser.java
@@ -100,6 +100,7 @@ public class LinkBrowser
 				return;
 			}
 			log.warn("LinkBrowser.open() could not open {}", directory);
+			showMessageBox("Unable to open folder. Press 'OK' and the folder directory will be copied to your clipboard.", url);
 		}).start();
 	}
 

--- a/src/main/java/net/runelite/launcher/LinkBrowser.java
+++ b/src/main/java/net/runelite/launcher/LinkBrowser.java
@@ -100,7 +100,7 @@ public class LinkBrowser
 				return;
 			}
 			log.warn("LinkBrowser.open() could not open {}", directory);
-			showMessageBox("Unable to open folder. Press 'OK' and the folder directory will be copied to your clipboard.", url);
+			showMessageBox("Unable to open folder. Press 'OK' and the folder directory will be copied to your clipboard.", directory);
 		}).start();
 	}
 

--- a/src/main/java/net/runelite/launcher/LinkBrowser.java
+++ b/src/main/java/net/runelite/launcher/LinkBrowser.java
@@ -79,7 +79,7 @@ public class LinkBrowser
          * The Linux Snap client in particular may block for up to five minutes using this call.
          * If the return values are not important to you, consider calling this method in its own thread.
 	 * @param directory directory to open
-	 * @return true if operation was correctly sent to the OS.
+	 * @return true if operation was successful
 	 */
 	public static boolean open(final String directory)
 	{

--- a/src/main/java/net/runelite/launcher/LinkBrowser.java
+++ b/src/main/java/net/runelite/launcher/LinkBrowser.java
@@ -70,9 +70,7 @@ public class LinkBrowser
 				return;
 			}
 			log.warn("LinkBrowser.browse() could not open {}", url);
-			return;
 		}).start();
-		return;
 	}
 
 	/**
@@ -81,7 +79,7 @@ public class LinkBrowser
 	 */
 	public static void open(final String directory)
 	{
-		new Thread(() -> 
+		new Thread(() ->
 		{
 			if (Strings.isNullOrEmpty(directory))
 			{
@@ -101,9 +99,7 @@ public class LinkBrowser
 				return;
 			}
 			log.warn("LinkBrowser.open() could not open {}", directory);
-			return;
 		}).start();
-		return;
 	}
 
 	private static boolean attemptXdgOpen(String resource)
@@ -204,5 +200,5 @@ public class LinkBrowser
 				Toolkit.getDefaultToolkit().getSystemClipboard().setContents(stringSelection, null);
 			}
 		});
-	}		
+	}
 }

--- a/src/main/java/net/runelite/launcher/LinkBrowser.java
+++ b/src/main/java/net/runelite/launcher/LinkBrowser.java
@@ -43,7 +43,6 @@ import lombok.extern.slf4j.Slf4j;
 public class LinkBrowser
 {
 	private static boolean shouldAttemptXdg = OS.getOs() == OS.OSType.Linux;
-	private static boolean isSnapClient = ! Strings.isNullOrEmpty(System.getenv("SNAP"));
 
 	/**
 	 * Tries to navigate to specified URL in browser. In case operation fails, displays message box with message
@@ -76,29 +75,17 @@ public class LinkBrowser
 
 	/**
 	 * Tries to open a directory in the OS native file manager.
+         * THIS METHOD MAY BLOCK FOR A SUBSTANTIAL AMOUNT OF TIME.
+         * The Linux Snap client in particular may block for up to five minutes using this call.
+         * If the return values are not important to you, consider calling this method in its own thread.
 	 * @param directory directory to open
-	 * @return true if operation was correctly sent to the OS, not necessarily true for whether the OS actually opened the directory (E.G, Snap)
+	 * @return true if operation was correctly sent to the OS.
 	 */
 	public static boolean open(final String directory)
 	{
 		if (Strings.isNullOrEmpty(directory))
 		{
 			return false;
-		}
-
-		//Snap specific workaround to prevent thread blocking on attempts to open folders.
-		if (isSnapClient)
-		{
-			try
-			{
-				Runtime.getRuntime().exec(new String[]{"xdg-open", directory});
-				log.debug("Attempted to open directory with snap workaround to {}", directory);
-			}
-			catch (IOException e)
-			{
-				log.warn("Snap specific error handling xdg-open {}", directory, e);
-			}
-			return true;
 		}
 
 		if (attemptDesktopOpen(directory))

--- a/src/main/java/net/runelite/launcher/LinkBrowser.java
+++ b/src/main/java/net/runelite/launcher/LinkBrowser.java
@@ -47,10 +47,15 @@ public class LinkBrowser
 	/**
 	 * Tries to navigate to specified URL in browser. In case operation fails, displays message box with message
 	 * and copies link to clipboard to navigate to.
-	 * @param url url to open
-	 * @return true if operation was successful
 	 */
-	public static boolean browse(final String url)
+	public static void browse(final String url)
+	{
+		Runnable task = () -> { attemptBrowse(url); };
+		new Thread(task).start();
+		return;
+	}
+
+	private static boolean attemptBrowse(final String url)
 	{
 		if (Strings.isNullOrEmpty(url))
 		{
@@ -75,13 +80,21 @@ public class LinkBrowser
 
 	/**
 	 * Tries to open a directory in the OS native file manager.
-         * THIS METHOD MAY BLOCK FOR A SUBSTANTIAL AMOUNT OF TIME.
-         * The Linux Snap client in particular may block for up to five minutes using this call.
-         * If the return values are not important to you, consider calling this method in its own thread.
+	 * @param directory directory to open
+	 */
+	public static void open(final String directory)
+	{
+		Runnable task = () -> { attemptOpen(directory); };
+		new Thread(task).start();
+		return;
+	}
+
+	/**
+	 * Tries to open a directory in the OS native file manager.
 	 * @param directory directory to open
 	 * @return true if operation was successful
 	 */
-	public static boolean open(final String directory)
+	private static boolean attemptOpen(final String directory)
 	{
 		if (Strings.isNullOrEmpty(directory))
 		{

--- a/src/main/java/net/runelite/launcher/LinkBrowser.java
+++ b/src/main/java/net/runelite/launcher/LinkBrowser.java
@@ -70,8 +70,8 @@ public class LinkBrowser
 				return;
 			}
 			log.warn("LinkBrowser.browse() could not open {}", url);
+			showMessageBox("Unable to open link. Press 'OK' and the link will be copied to your clipboard.", url);
 		}).start();
-		showMessageBox("Unable to open link. Press 'OK' and the link will be copied to your clipboard.", url);
 	}
 
 	/**


### PR DESCRIPTION
This should allow systems without GVFS to open the logs folder. This applies to the AppImage on none Gnome or bare bone systems, the raw Jar, and Snap.
