### PR TITLE
osx: update jre to 11.0.7+10

### DIFF
--- a/build-osx.sh
+++ b/build-osx.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-JDK_VER="11.0.4"
-JDK_BUILD="11"
+JDK_VER="11.0.7"
+JDK_BUILD="10"
 PACKR_VERSION="runelite-1.0"
 
 SIGNING_IDENTITY="Developer ID Application"
@@ -15,14 +15,14 @@ if ! [ -f OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz ] ; then
         https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz
 fi
 
-echo "1647fded28d25e562811f7bce2092eb9c21d30608843b04250c023b40604ff26  OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz" | shasum -c
+echo "931a81f4bed38c48b364db57d4ebdd6e4b4ea1466e9bd0eaf8e0f1e47c4569e9  OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz" | shasum -c
 
 # packr requires a "jdk" and pulls the jre from it - so we have to place it inside
 # the jdk folder at jre/
 if ! [ -d osx-jdk ] ; then
     tar zxf OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz
     mkdir osx-jdk
-    mv jdk-11.0.4+11-jre osx-jdk/jre
+    mv jdk-${JDK_VER}+${JDK_BUILD}-jre osx-jdk/jre
 
     # Move JRE out of Contents/Home/
     pushd osx-jdk/jre

--- a/osx/signing.entitlements
+++ b/osx/signing.entitlements
@@ -2,5 +2,13 @@
 <dict>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-executable-page-protection</key>
+	<true/>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
To fix an issue with minimizing the client (#81).

A few more entitlements are disabled to get the JRE to run when our launcher is signed, as per  https://github.com/AdoptOpenJDK/openjdk-build/issues/1130#issuecomment-516356299.