### PR TITLE
Add LSEnvironment key to Info.plist

### DIFF
--- a/packr/Info.plist
+++ b/packr/Info.plist
@@ -31,7 +31,7 @@
   <key>LSEnvironment</key>
   <dict>
     <key>PATH</key>
-    <string>/usr/local/bin:</string>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
   </dict>
 </dict>
 </plist>

--- a/packr/Info.plist
+++ b/packr/Info.plist
@@ -28,5 +28,10 @@
   <true/>
   <key>NSRequiresAquaSystemAppearance</key>
   <false/>
+  <key>LSEnvironment</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:</string>
+  </dict>
 </dict>
 </plist>


### PR DESCRIPTION
Add `/urs/local/bin` to PATH to be able to check for availability of terminal-notifier in macOS

@Broooker:
> It seems the issue revolves around Finder-launched applications not having a path to `/usr/local/bin/` so it's unable to access the symlinked `/usr/local/bin/terminal-notifier` or the original location.

This solves the issue by adding `/usr/local/bin` to the application's PATH environment variable, allowing it to check for terminal-notifier.

Fixes runelite/runelite#12427