### PR TITLE
snap: Bundle GVFS to fix web links not opening

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,7 @@ parts:
       - libpulse0
       - libasound2
       - libasound2-plugins
+      - gvfs
     override-pull: |
       snapcraftctl pull
       find . -not -name 'RuneLite.jar' -delete
@@ -82,3 +83,4 @@ apps:
     environment:
       _JAVA_OPTIONS: -Duser.home="$SNAP_USER_COMMON"
       ALSA_CONFIG_PATH: "$SNAP/etc/asound.conf"
+      LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:${SNAP}/usr/lib/x86_64-linux-gnu/gvfs"


### PR DESCRIPTION
The vanilla client fails to open web browsers on Linux systems in the event GVFS isn't installed. These are not covered by the xdg-open fallback functionality that RuneLite's plugins use.
This commit is enough to ensure every snap user has enough of GFVS to catch the cases the xdg-open functionality doesn't cover.