### PR TITLE
snap: Upgrade to core20 base

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: runelite
-base: core18
+base: core20
 title: RuneLite
 version: git
 summary: A popular free, open-source and super fast client for Old School RuneScape
@@ -62,10 +62,6 @@ parts:
 layout:
   /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/alsa-lib:
     bind: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/alsa-lib
-  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.0:
-    bind: $SNAP/gnome-platform/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.0
-  /usr/share/xml/iso-codes:
-    bind: $SNAP/gnome-platform/usr/share/xml/iso-codes
 
 apps:
   runelite:
@@ -77,8 +73,9 @@ apps:
       - audio-playback
       - x11
       - opengl
+      - pulseaudio
 
-    extensions: [ gnome-3-28 ]
+    extensions: [ gnome-3-38 ]
     environment:
       _JAVA_OPTIONS: -Duser.home="$SNAP_USER_COMMON"
       ALSA_CONFIG_PATH: "$SNAP/etc/asound.conf"


### PR DESCRIPTION
The current RuneLite snap is using Ubuntu 18.04 as a base image, with Gnome-3-28 libraries supplemented alongside it.

Upgrading to core20 will mean all snap users will be using the equivilent Mesa libraries from Ubuntu 20.04 and should be beneficial to performance and stability regarding the GPU plugin.

It'll also fix some font related issues with Arch/Manjaro users.

Users should be entirely blind to this transition.

For the time being, Gnome-3-38 is still marked as an experimental extension and so the flag `--enable-experimental-extensions` would need to be used (I.E: `snapcraft --enable-experimental-extensions`), however this is experimental in the sense small build semantics might change and not in the sense it's not fit for purpose, removal of this flag is expected in a few weeks and the build file should look the same.