### PR TITLE
snap: Bundle notify-send, arm64 support, remove pulseaudio interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,9 @@ license: BSD-2-Clause
 parts:
   adoptopenjdk:
     plugin: dump
-    source: https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.8%2B10/OpenJDK11U-jre_x64_linux_hotspot_11.0.8_10.tar.gz
+    source: 
+      - on amd64: https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.8%2B10/OpenJDK11U-jre_x64_linux_hotspot_11.0.8_10.tar.gz
+      - on arm64: https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.11_9.tar.gz
     stage-packages:
       - libxi6
       - libxrender1
@@ -30,6 +32,7 @@ parts:
       - libpulse0
       - libasound2
       - libasound2-plugins
+      - libnotify-bin
     override-pull: |
       snapcraftctl pull
       find . -not -name 'RuneLite.jar' -delete
@@ -73,7 +76,6 @@ apps:
       - audio-playback
       - x11
       - opengl
-      - pulseaudio
 
     extensions: [ gnome-3-38 ]
     environment:


### PR DESCRIPTION
notify-send has been explicitly added to the stage-package to enable desktop notifications.

arm64 will probably work assuming the build process is run on an arm64 host (real or emulated).
Such a snap file could be submitted to the store where it would be delivered to arm64 clients as expected.
This hasn't actually been tested to work however.

The Pulseaudio interface has been removed. It was added in the previous snap patch to fix legacy
snapd clients that didn't understand the "audio-playback" interface. However, the Gnome-3-38
extension since enforces a minimum snapd version that ensures all users wouldn't need
the legacy "pulseaudio" interface. The functional difference is that audio-playback
does not grant access to the microphone unlike Pulseaudio.