### PR TITLE
snap: remove pulseaudio interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,7 +73,6 @@ apps:
       - audio-playback
       - x11
       - opengl
-      - pulseaudio
 
     extensions: [ gnome-3-38 ]
     environment:


### PR DESCRIPTION
The pulseaudio interface added in c45af5a4e86ee291196aced122413951dc9d3ae3 is no longer required.

The Gnome-3-38 extension now demands a version of snapd that is guaranteed to understand
the audio-playback interface. As such, the pulseaudio interface is unnecessary and
over privileged.