### PR TITLE
snap: Bundle notify-send

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,7 @@ parts:
       - libpulse0
       - libasound2
       - libasound2-plugins
+      - libnotify-bin
     override-pull: |
       snapcraftctl pull
       find . -not -name 'RuneLite.jar' -delete


### PR DESCRIPTION
This ensures notifications sent via notify-send will be available.