### PR TITLE
Ensure host umask does not interfere with AppImage permissions

### DIFF
--- a/build-linux-aarch64.sh
+++ b/build-linux-aarch64.sh
@@ -64,11 +64,12 @@ java -jar packr_${PACKR_VERSION}.jar \
 pushd native-linux-aarch64/RuneLite.AppDir
 mkdir -p jre/lib/amd64/server/
 ln -s ../../server/libjvm.so jre/lib/amd64/server/ # packr looks for libjvm at this hardcoded path
-popd
 
 # Symlink AppRun -> RuneLite
-pushd native-linux-aarch64/RuneLite.AppDir/
 ln -s RuneLite AppRun
+
+# Ensure RuneLite is executable to all users
+chmod 755 RuneLite
 popd
 
 if ! [ -f appimagetool-x86_64.AppImage ] ; then

--- a/build-linux-aarch64.sh
+++ b/build-linux-aarch64.sh
@@ -7,6 +7,8 @@ JDK_BUILD="10"
 PACKR_VERSION="runelite-1.1"
 APPIMAGE_VERSION="12"
 
+umask 022
+
 if ! [ -f OpenJDK11U-jre_aarch64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz ] ; then
     curl -Lo OpenJDK11U-jre_aarch64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz \
         https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_aarch64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz
@@ -28,6 +30,11 @@ if ! [ -f packr_${PACKR_VERSION}.jar ] ; then
 fi
 
 echo "ee3b0386d7a6474b042429e2fe7826fd40088258aec05707f0c722d773b5b1bd  packr_${PACKR_VERSION}.jar" | sha256sum -c
+
+# Note: Host umask may have checked out this directory with g/o permissions blank
+chmod -R u=rwX,go=rX appimage
+# ...ditto for the build process
+chmod 644 target/RuneLite.jar
 
 rm -rf native-linux-aarch64
 

--- a/build-linux-x86_64.sh
+++ b/build-linux-x86_64.sh
@@ -62,11 +62,12 @@ java -jar packr_${PACKR_VERSION}.jar \
 pushd native-linux-x86_64/RuneLite.AppDir
 mkdir -p jre/lib/amd64/server/
 ln -s ../../server/libjvm.so jre/lib/amd64/server/ # packr looks for libjvm at this hardcoded path
-popd
 
 # Symlink AppRun -> RuneLite
-pushd native-linux-x86_64/RuneLite.AppDir/
 ln -s RuneLite AppRun
+
+# Ensure RuneLite is executable to all users
+chmod 755 RuneLite
 popd
 
 if ! [ -f appimagetool-x86_64.AppImage ] ; then

--- a/build-linux-x86_64.sh
+++ b/build-linux-x86_64.sh
@@ -7,6 +7,8 @@ JDK_BUILD="10"
 PACKR_VERSION="runelite-1.0"
 APPIMAGE_VERSION="12"
 
+umask 022
+
 if ! [ -f OpenJDK11U-jre_x64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz ] ; then
     curl -Lo OpenJDK11U-jre_x64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz \
         https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz
@@ -28,6 +30,11 @@ if ! [ -f packr_${PACKR_VERSION}.jar ] ; then
 fi
 
 echo "18b7cbaab4c3f9ea556f621ca42fbd0dc745a4d11e2a08f496e2c3196580cd53  packr_${PACKR_VERSION}.jar" | sha256sum -c
+
+# Note: Host umask may have checked out this directory with g/o permissions blank
+chmod -R u=rwX,go=rX appimage
+# ...ditto for the build process
+chmod 644 target/RuneLite.jar
 
 java -jar packr_${PACKR_VERSION}.jar \
     --platform \


### PR DESCRIPTION
My default umask is `077`, and running the build process and appimage scripts with that umask active causes some of the files to get bad permissions. This shouldn't have much of an effect on the current build host which appears to have a umask of `002` (default for many server distros), but it was necessary when testing [packr changes](https://github.com/runelite/packr/pull/1) on my local machine.

User-only permissions [interact with firejail](https://github.com/runelite/runelite/issues/14519) in unexpected ways so this should fix that aspect.