### PR TITLE
Handle CMD+Q inputs correctly on MacOS

### DIFF
--- a/src/main/java/net/runelite/launcher/SplashScreen.java
+++ b/src/main/java/net/runelite/launcher/SplashScreen.java
@@ -158,6 +158,10 @@ public class SplashScreen extends JFrame implements ActionListener
 	{
 		try
 		{
+			if (OS.getOs() == OS.OSType.MacOS)
+			{
+				System.setProperty("apple.eawt.quitStrategy", "CLOSE_ALL_WINDOWS");
+			}
 			SwingUtilities.invokeAndWait(() ->
 			{
 				if (INSTANCE != null)
@@ -191,6 +195,11 @@ public class SplashScreen extends JFrame implements ActionListener
 				return;
 			}
 
+			// The instance sometimes sticks around after disposal.
+			// When it does, the EXIT_ON_CLOSE operation interferes with CMD+Q on MacOS.
+			// To get around this, set DO_NOTHING_ON_CLOSE before disposing.
+			INSTANCE.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
+			
 			INSTANCE.timer.stop();
 			INSTANCE.dispose();
 			INSTANCE = null;


### PR DESCRIPTION
May require the setDefaultCloseOperation change from https://github.com/runelite/runelite/pull/14539.

Copying from that PR:

> On MacOS, CMD+Q should result in a soft exit, which can allow for user confirmation, rather than a hard exit. Setting the "apple.eawt.quitStrategy" property to "CLOSE_ALL_WINDOWS" accomplishes this. However, the property has to be set before the _AppEventHandler is initialized and reads that property, which happens when SwingUtilities.invokeLater() is first called in SplashScreen.java.
> 
> Setting the "apple.eawt.quitStrategy" property to "CLOSE_ALL_WINDOWS" results in a windowClosing event being sent to each JFrame. If any of them handle that by exiting, the program will exit. Otherwise, the program will continue as if CMD+Q was not entered. The current SplashScreen windowClosing handling is EXIT_ON_CLOSE, so change it to DO_NOTHING_ON_CLOSE.