### PR TITLE
Adjust Info.plist keys

### DIFF
--- a/packr/Info.plist
+++ b/packr/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleGetInfoString</key>
-  <string>${project.build.finalName}</string>
   <key>CFBundleExecutable</key>
   <string>${project.build.finalName}</string>
   <key>CFBundleIdentifier</key>
@@ -33,5 +31,7 @@
     <key>PATH</key>
     <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
   </dict>
+  <key>LSRequiresNativeExecution</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Since a launcher update seems imminent, here's a PR that can hopefully be included.

There are two changes, both to the `Info.plist` file:
- CFBundleGetInfoString is removed. CFBundleGetInfoString overrides the version number defined in CFBundleShortVersionString, causing "RuneLite" to be displayed as the version in the Get Info menu. It's also considered obsolete.
- LSRequiresNativeExecution is added. LSRequiresNativeExecution removes the ability for users to tell the m1 version to run using Rosetta. Since the m1 version doesn't work using Rosetta and attempting to run it like that prevents the app from starting, removing this option seems like a good idea.
  - edit: This also prevents the x86 version from running on an m1 mac, but I don't see why that would be desired behavior anyway with the m1 version available and seemingly issue-less.

Get Info menu before:
<img width="245" alt="getinfo-before" src="https://user-images.githubusercontent.com/96100526/154846472-92506b69-6b58-4fd8-b6c8-e60477714bcd.png">

Get Info menu after:
<img width="258" alt="getinfo-after" src="https://user-images.githubusercontent.com/96100526/154846477-02096a31-6e5b-42ac-a74d-2df9ccaf4944.png">
