### PR TITLE
Added support for XDG directory standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,12 @@ project.properties
 .settings/
 .classpath
 dependency-reduced-pom.xml
-*.exe
+*.exelinux-jdk
+linux-aarch64-jdk/
+native-linux-x86_64/
+native-linux-aarch64/
+linux-jdk/
+*.AppImage
+*.AppImage-patched
+OpenJDK11U-jre_*_linux_hotspot_*.tar.gz
+packr_runelite-*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ project.properties
 .settings/
 .classpath
 dependency-reduced-pom.xml
-*.exelinux-jdk
+*.exe
+linux-jdk/
 linux-aarch64-jdk/
 native-linux-x86_64/
 native-linux-aarch64/

--- a/src/main/java/net/runelite/launcher/OS.java
+++ b/src/main/java/net/runelite/launcher/OS.java
@@ -36,10 +36,16 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class OS
 {
+	/*
+	 * XDG prefixed variables are OS-defaults
+	 * non-prefixed variables are the running environment variables
+	 * the minuscule variables are the runelite-specific variables
+	 * */
 	private static final Path CONFIG_HOME;
 	private static final Path DATA_HOME;
 	private static final Path CACHE_HOME;
 	private static final Path STATE_HOME;
+	private static final Path PICTURES_DIR;
 
 	public enum OSType
 	{
@@ -59,6 +65,7 @@ public class OS
 		Path XDG_DATA_HOME;
 		Path XDG_CACHE_HOME;
 		Path XDG_STATE_HOME;
+		Path XDG_PICTURES_DIR;
 
 		if (os.contains("mac") || os.contains("darwin"))
 		{
@@ -67,6 +74,8 @@ public class OS
 			XDG_CACHE_HOME = Paths.get(System.getProperty("user.home"), "Library", "Caches");
 			// STATE is a newcomer to the standard. it was split apart from the cache directory... but not on MacOS (yet, at least)
 			XDG_STATE_HOME = Paths.get(System.getProperty("user.home"), "Library", "Caches");
+
+			XDG_PICTURES_DIR = Paths.get(System.getProperty("user.home"), "Pictures");
 
 			DETECTED_OS = OSType.MacOS;
 		}
@@ -78,6 +87,8 @@ public class OS
 			// STATE is a newcomer to the standard. it was split apart from the cache directory... but not on Windows (yet, at least)
 			XDG_STATE_HOME = Paths.get(System.getProperty("user.home"), "AppData", "Local", placeholder, "Cache");
 
+			XDG_PICTURES_DIR = Paths.get(System.getProperty("user.home"), "Pictures");
+
 			DETECTED_OS = OSType.Windows;
 		}
 		else if (os.contains("linux"))
@@ -86,6 +97,8 @@ public class OS
 			XDG_DATA_HOME = Paths.get(System.getProperty("user.home"), ".local", "share");
 			XDG_CACHE_HOME = Paths.get(System.getProperty("user.home"), ".cache");
 			XDG_STATE_HOME = Paths.get(System.getProperty("user.home"), ".local", "state");
+
+			XDG_PICTURES_DIR = Paths.get(System.getProperty("user.home"), "Pictures");
 
 			DETECTED_OS = OSType.Linux;
 		}
@@ -96,15 +109,21 @@ public class OS
 			XDG_CACHE_HOME = Paths.get(System.getProperty("user.home"), ".runelite", "cache");
 			XDG_STATE_HOME = Paths.get(System.getProperty("user.home"), ".runelite", "state");
 
+			XDG_PICTURES_DIR = Paths.get(System.getProperty("user.home"), ".runelite", "Pictures");
+
 			DETECTED_OS = OSType.Other;
 		}
 
+		XDG_PICTURES_DIR = Paths.get(System.getProperty("user.home"), "Pictures");
 
 		// note: system variables don't have a placeholder for the appname.
 		CONFIG_HOME = Paths.get(System.getProperty("XDG_CONFIG_HOME", XDG_CONFIG_HOME.toString()));
 		DATA_HOME = Paths.get(System.getProperty("XDG_DATA_HOME", XDG_DATA_HOME.toString()));
 		CACHE_HOME = Paths.get(System.getProperty("XDG_CACHE_HOME", XDG_CACHE_HOME.toString()));
 		STATE_HOME = Paths.get(System.getProperty("XDG_STATE_HOME", XDG_STATE_HOME.toString()));
+
+		PICTURES_DIR = Paths.get(System.getProperty("XDG_PICTURES_DIR", XDG_PICTURES_DIR.toString()));
+
 		log.debug("Detect OS: {}", DETECTED_OS);
 	}
 
@@ -164,6 +183,7 @@ public class OS
 		String data_home;
 		String cache_home;
 		String state_home;
+		String pictures_dir;
 
 		if (OS.equals("windows"))
 		{
@@ -179,6 +199,7 @@ public class OS
 			cache_home = Paths.get(CACHE_HOME.toString(), appName).toString();
 			state_home = Paths.get(STATE_HOME.toString(), appName).toString();
 		}
+		pictures_dir = Paths.get(PICTURES_DIR.toString(), appName).toString();
 
 		switch (home.toLowerCase())
 		{
@@ -190,6 +211,9 @@ public class OS
 				return cache_home;
 			case "state":
 				return state_home;
+			case "pictures":
+			case "screenshots":
+				return pictures_dir;
 			default:
 				throw new IllegalArgumentException("XDG paths must be config, data, cache or state");
 		}

--- a/src/main/java/net/runelite/launcher/OS.java
+++ b/src/main/java/net/runelite/launcher/OS.java
@@ -24,32 +24,104 @@
  */
 package net.runelite.launcher;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
+
+/*
+   */
 
 @Slf4j
 public class OS
 {
+	private static final Path CONFIG_HOME;
+	private static final Path DATA_HOME;
+	private static final Path CACHE_HOME;
+	private static final Path STATE_HOME;
+
 	public enum OSType
 	{
 		Windows, MacOS, Linux, Other
 	}
 
 	private static final OSType DETECTED_OS;
+	private static final String DETECTED_ARCH;
 
+	private static final String placeholder = "%{project_name}";  // used on Windows
 	static
 	{
-		final String os = System
-			.getProperty("os.name", "generic")
-			.toLowerCase();
-		DETECTED_OS = parseOs(os);
+		String os = System.getProperty("os.name", "generic").toLowerCase();
+		DETECTED_ARCH = System.getProperty("os.arch", "unknown");
+
+		Path XDG_CONFIG_HOME;
+		Path XDG_DATA_HOME;
+		Path XDG_CACHE_HOME;
+		Path XDG_STATE_HOME;
+
+		if (os.contains("mac") || os.contains("darwin"))
+		{
+			XDG_CONFIG_HOME = Paths.get(System.getProperty("user.home"), "Library", "Preferences");
+			XDG_DATA_HOME = Paths.get(System.getProperty("user.home"), "Library", "Application Support");
+			XDG_CACHE_HOME = Paths.get(System.getProperty("user.home"), "Library", "Caches");
+			// STATE is a newcomer to the standard. it was split apart from the cache directory... but not on MacOS (yet, at least)
+			XDG_STATE_HOME = Paths.get(System.getProperty("user.home"), "Library", "Caches");
+
+			DETECTED_OS = OSType.MacOS;
+		}
+		else if (os.contains("win"))
+		{
+			XDG_CONFIG_HOME = Paths.get(System.getProperty("user.home"), "AppData", "Roaming", placeholder, "Config");
+			XDG_DATA_HOME = Paths.get(System.getProperty("user.home"), "AppData", "Local", placeholder, "Data" );
+			XDG_CACHE_HOME = Paths.get(System.getProperty("user.home"), "AppData", "Local", placeholder, "Cache");
+			// STATE is a newcomer to the standard. it was split apart from the cache directory... but not on Windows (yet, at least)
+			XDG_STATE_HOME = Paths.get(System.getProperty("user.home"), "AppData", "Local", placeholder, "Cache");
+
+			DETECTED_OS = OSType.Windows;
+		}
+		else if (os.contains("linux"))
+		{
+			XDG_CONFIG_HOME = Paths.get(System.getProperty("user.home"), ".config");
+			XDG_DATA_HOME = Paths.get(System.getProperty("user.home"), ".local", "share");
+			XDG_CACHE_HOME = Paths.get(System.getProperty("user.home"), ".cache");
+			XDG_STATE_HOME = Paths.get(System.getProperty("user.home"), ".local", "state");
+
+			DETECTED_OS = OSType.Linux;
+		}
+		else
+		{
+			XDG_CONFIG_HOME = Paths.get(System.getProperty("user.home"), ".runelite", "config");
+			XDG_DATA_HOME = Paths.get(System.getProperty("user.home"), ".runelite", "data");
+			XDG_CACHE_HOME = Paths.get(System.getProperty("user.home"), ".runelite", "cache");
+			XDG_STATE_HOME = Paths.get(System.getProperty("user.home"), ".runelite", "state");
+
+			DETECTED_OS = OSType.Other;
+		}
+
+
+		// note: system variables don't have a placeholder for the appname.
+		CONFIG_HOME = Paths.get(System.getProperty("XDG_CONFIG_HOME", XDG_CONFIG_HOME.toString()));
+		DATA_HOME = Paths.get(System.getProperty("XDG_DATA_HOME", XDG_DATA_HOME.toString()));
+		CACHE_HOME = Paths.get(System.getProperty("XDG_CACHE_HOME", XDG_CACHE_HOME.toString()));
+		STATE_HOME = Paths.get(System.getProperty("XDG_STATE_HOME", XDG_STATE_HOME.toString()));
 		log.debug("Detect OS: {}", DETECTED_OS);
 	}
 
-	static OSType parseOs(@Nonnull String os)
+
+	public static OSType getOs(@Nonnull String os)
 	{
-		os = os.toLowerCase();
-		if ((os.contains("mac")) || (os.contains("darwin")))
+		return getOS(os);
+	}
+
+	public static OSType getOs()
+	{
+		return getOS();
+	}
+
+	public static OSType getOS(@Nonnull String os)
+	{
+		if (os.contains("mac") || os.contains("darwin"))
 		{
 			return OSType.MacOS;
 		}
@@ -67,8 +139,79 @@ public class OS
 		}
 	}
 
-	public static OSType getOs()
+	public static OSType getOS()
 	{
 		return DETECTED_OS;
+	}
+	public static String getArch()
+	{
+		return DETECTED_ARCH;
+	}
+
+	public static boolean equals(String os)
+	{
+		return DETECTED_OS.equals(getOS(os.toLowerCase()));
+	}
+
+	public static String getXDG(@Nonnull String home, String appName) throws IllegalArgumentException
+	{
+		if (appName == null)
+		{
+			appName = "";
+		}
+
+		String config_home;
+		String data_home;
+		String cache_home;
+		String state_home;
+
+		if (OS.equals("windows"))
+		{
+			config_home = CONFIG_HOME.toString().replace(placeholder, appName);
+			data_home = DATA_HOME.toString().replace(placeholder, appName);
+			cache_home = CACHE_HOME.toString().replace(placeholder, appName);
+			state_home = STATE_HOME.toString().replace(placeholder, appName);
+		}
+		else
+		{
+			config_home = Paths.get(CONFIG_HOME.toString(), appName).toString();
+			data_home = Paths.get(DATA_HOME.toString(), appName).toString();
+			cache_home = Paths.get(CACHE_HOME.toString(), appName).toString();
+			state_home = Paths.get(STATE_HOME.toString(), appName).toString();
+		}
+
+		switch (home.toLowerCase())
+		{
+			case "config":
+				return config_home; 
+			case "data":
+				return data_home;
+			case "cache":
+				return cache_home;
+			case "state":
+				return state_home;
+			default:
+				throw new IllegalArgumentException("XDG paths must be config, data, cache or state");
+		}
+	}
+	
+	public static boolean isCompatible(String platformName, String platformArch)
+	{
+		if (platformName == null)
+		{
+			return false;
+		}
+
+		OSType platformOS = OS.getOS(platformName);
+
+		// we should document why we are using the platform name when we don't find a match for the platform os
+		if (platformOS == OSType.Other ? platformName.equals(DETECTED_OS) : platformOS == DETECTED_OS)
+		{
+			if (platformArch == null || platformArch.equals(DETECTED_ARCH))
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
For a long time I've had to create symlinks in my system so that Runelite doesn't pollute my home directory. Sufficient to say, this is not fun.

I added support for XDG standards, and is now the default on both Linux and MacOS versions.

- `RUNELITE_DIR` is now `XDG_DATA_HOME/runelite`.
- `LOGS_DIR` is now `XDG_STATE_HOME/runelite`.
- `REPO_DIR` hasn't changed: `RUNELITE_DIR/repository2` (documenting what this directory means would be nice)
- `CRASH_FILES` haven't changed: `LOGS_DIR/jvm_crash_pid_%p.log`

Furthermore, we should now use `OS.getXDG("config", "runelite")`, `OS.getXDG("data", "runelite")`, `OS.getXDG("cache", "runelite")`, and `OS.getXDG("state", "runelite")`, `OS.getXDG("pictures", "runelite")` to appropriately place stuff. Replace `"runelite"` with `"runescape"` if that makes more sense for certain things.

With this, we should move towards separating `runescape`-specific stuff from `runelite` specific stuff, and make sure plugins also follow up. We should probably also move configuration into the configuration directory, and add a configuration file for each plugin under a subdirectory.

**Important note for Linux and MacOS users**: Manually move the directories from `~/.runelite` into the ones specified above! Nothing will be lost if you don't do it, but it's not automatic.

- added support for XDG base directory. only enforced on linux and macOS
- added linux targets to gitignore
- added XDG variable for screenshots
