### PR TITLE
Info.plist: account for macports and nix in PATH

### DIFF
--- a/packr/Info.plist
+++ b/packr/Info.plist
@@ -29,7 +29,7 @@
   <key>LSEnvironment</key>
   <dict>
     <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <string>/usr/local/bin:/opt/local/bin:/run/current-system/sw/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
   </dict>
   <key>LSRequiresNativeExecution</key>
   <true/>


### PR DESCRIPTION
These are the `bin` paths used by the other two macOS package managers of note. With this, Macports and Nix users can let RL use their `terminal-notifier` installs too. In future, acquiring `$PATH` by running a login shell might be more robust, but for the time being, this should do.