### PR TITLE
Implement macOS Sonoma Game Mode

### DIFF
--- a/osx/Info.plist
+++ b/osx/Info.plist
@@ -26,6 +26,8 @@
   <true/>
   <key>NSRequiresAquaSystemAppearance</key>
   <false/>
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.games</string>
   <key>LSEnvironment</key>
   <dict>
     <key>PATH</key>


### PR DESCRIPTION
Closes #117 

macOS Sonoma introduced [Game Mode](https://support.apple.com/en-us/HT213658), which "optimizes your gaming experience by giving your game the highest priority access to your CPU and GPU, lowering usage for background tasks." Game Mode is enabled when a supported application enters fullscreen.

Game Mode documentation is virtually nonexistant. However, an application will be recognized as a game by setting `LSApplicationCategoryType` to `public.app-category.games` in the app's Info.plist.

Testing on my 2021 M1 Pro MBP yielded negligible FPS increases. However, I believe this macOS feature should be supported regardless.

<img width="1168" alt="macOS Game Mode" src="https://github.com/runelite/launcher/assets/6306331/ccd2ecc2-0da3-4ba3-9580-cab38aa5310d">

More information on Game Mode:
https://eclecticlight.co/2023/10/17/what-does-game-mode-do/
https://eclecticlight.co/2023/10/18/how-game-mode-manages-cpu-and-gpu/