### PR TITLE
Fix file permissions and attributes

### DIFF
--- a/liblauncher/CMakeLists.txt
+++ b/liblauncher/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 find_package(JNI REQUIRED)
 
-add_library(launcher SHARED main.cpp reg.cpp)
+add_library(launcher SHARED main.cpp reg.cpp elevation.cpp)
 include_directories(../detours/include ${JNI_INCLUDE_DIRS})
 if (CMAKE_GENERATOR_PLATFORM STREQUAL "x64")
     set_target_properties(launcher PROPERTIES OUTPUT_NAME "launcher_amd64")

--- a/liblauncher/elevation.cpp
+++ b/liblauncher/elevation.cpp
@@ -1,0 +1,107 @@
+#include <Windows.h>
+#include <shlobj.h>
+#include <atlbase.h>
+#include <jni.h>
+
+extern "C" JNIEXPORT jboolean JNICALL Java_net_runelite_launcher_FilePermissionManager_isRunningElevated(JNIEnv *env, jclass clazz, jlong pid) {
+	BOOL fRet = false;
+	HANDLE hToken = nullptr;
+	HANDLE handle = OpenProcess(PROCESS_ALL_ACCESS, TRUE, pid);
+	// alternatively use GetCurrentProcess() instead if you'd only want to check the current process
+	if (OpenProcessToken(handle, TOKEN_QUERY, &hToken)) {
+		TOKEN_ELEVATION Elevation;
+		DWORD cbSize = sizeof(TOKEN_ELEVATION);
+		if (GetTokenInformation(hToken, TokenElevation, &Elevation, sizeof(Elevation), &cbSize)) {
+			fRet = Elevation.TokenIsElevated;
+		}
+	}
+	CloseHandle(handle);
+	if (hToken) {
+		CloseHandle(hToken);
+	}
+	bool result = fRet == 1 ? true : false;
+	return result;
+}
+
+extern "C" JNIEXPORT void JNICALL Java_net_runelite_launcher_FilePermissionManager_elevate(JNIEnv *env, jclass clazz, jstring pathObj, jstring argsObj) {
+	const jchar *pathString = env->GetStringChars(pathObj, nullptr);
+	const jchar *argsString = env->GetStringChars(argsObj, nullptr);
+
+	ShellExecuteW(nullptr, L"runas", reinterpret_cast<const wchar_t *>(pathString), reinterpret_cast<const wchar_t *>(argsString), nullptr, SW_SHOWNORMAL);
+
+	env->ReleaseStringChars(pathObj, pathString);
+	env->ReleaseStringChars(argsObj, argsString);
+}
+
+// https://devblogs.microsoft.com/oldnewthing/20130318-00/?p=4933
+void FindDesktopFolderView(REFIID riid, void** ppv) {
+	CComPtr<IShellWindows> spShellWindows;
+	spShellWindows.CoCreateInstance(CLSID_ShellWindows);
+
+	CComVariant vtLoc(CSIDL_DESKTOP);
+	CComVariant vtEmpty;
+	long lhwnd;
+	CComPtr<IDispatch> spdisp;
+	spShellWindows->FindWindowSW(
+		&vtLoc, &vtEmpty,
+		SWC_DESKTOP, &lhwnd,
+		SWFO_NEEDDISPATCH, &spdisp);
+
+	CComPtr<IShellBrowser> spBrowser;
+	CComQIPtr<IServiceProvider>(spdisp)->
+		QueryService(SID_STopLevelBrowser,
+			IID_PPV_ARGS(&spBrowser));
+
+	CComPtr<IShellView> spView;
+	spBrowser->QueryActiveShellView(&spView);
+
+	spView->QueryInterface(riid, ppv);
+}
+
+// https://devblogs.microsoft.com/oldnewthing/20131118-00/?p=2643
+void GetDesktopAutomationObject(REFIID riid, void** ppv)
+{
+	CComPtr<IShellView> spsv;
+	FindDesktopFolderView(IID_PPV_ARGS(&spsv));
+	CComPtr<IDispatch> spdispView;
+	spsv->GetItemObject(SVGIO_BACKGROUND, IID_PPV_ARGS(&spdispView));
+	spdispView->QueryInterface(riid, ppv);
+}
+
+void ShellExecuteFromExplorer(
+	PCWSTR pszFile,
+	PCWSTR pszParameters = nullptr,
+	PCWSTR pszDirectory = nullptr,
+	PCWSTR pszOperation = nullptr,
+	int nShowCmd = SW_SHOWNORMAL) {
+	CComPtr<IShellFolderViewDual> spFolderView;
+	GetDesktopAutomationObject(IID_PPV_ARGS(&spFolderView));
+	CComPtr<IDispatch> spdispShell;
+	spFolderView->get_Application(&spdispShell);
+	CComQIPtr<IShellDispatch2>(spdispShell)
+		->ShellExecute(CComBSTR(pszFile),
+			CComVariant(pszParameters ? pszParameters : L""),
+			CComVariant(pszDirectory ? pszDirectory : L""),
+			CComVariant(pszOperation ? pszOperation : L""),
+			CComVariant(nShowCmd));
+}
+
+// https://devblogs.microsoft.com/oldnewthing/20040520-00/?p=39243
+class CCoInitialize {
+public:
+	CCoInitialize() : m_hr(CoInitialize(nullptr)) { }
+	~CCoInitialize() { if (SUCCEEDED(m_hr)) CoUninitialize(); }
+	operator HRESULT() const { return m_hr; }
+	HRESULT m_hr;
+};
+
+extern "C" JNIEXPORT void JNICALL Java_net_runelite_launcher_FilePermissionManager_unelevate(JNIEnv *env, jclass clazz, jstring pathObj, jstring argsObj) {
+	const jchar *pathString = env->GetStringChars(pathObj, nullptr);
+	const jchar *argsString = env->GetStringChars(argsObj, nullptr);
+
+	CCoInitialize init;
+	ShellExecuteFromExplorer(reinterpret_cast<const wchar_t *>(pathString),	reinterpret_cast<const wchar_t *>(argsString), L"", L"", SW_SHOWNORMAL);
+
+	env->ReleaseStringChars(pathObj, pathString);
+	env->ReleaseStringChars(argsObj, argsString);
+}

--- a/src/main/java/net/runelite/launcher/FilePermissionManager.java
+++ b/src/main/java/net/runelite/launcher/FilePermissionManager.java
@@ -1,0 +1,516 @@
+/*
+ * Copyright (c) 2024, YvesW <https://github.com/YvesW>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.launcher;
+
+import java.awt.Color;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.imageio.ImageIO;
+import javax.swing.ImageIcon;
+import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import lombok.extern.slf4j.Slf4j;
+import static net.runelite.launcher.Launcher.LOGS_DIR;
+import static net.runelite.launcher.Launcher.REPO_DIR;
+import static net.runelite.launcher.Launcher.RUNELITE_DIR;
+import static net.runelite.launcher.Launcher.filePermsStep;
+import static net.runelite.launcher.Launcher.nativesLoaded;
+
+@Slf4j
+public class FilePermissionManager
+{
+	private static final File PROFILES_DIR = new File(RUNELITE_DIR, "profiles2");
+	private static final Color DARKER_GRAY_COLOR = new Color(30, 30, 30);
+
+	static void verifyFixFilePerms()
+	{
+		verifyFixFilePerms(false);
+	}
+
+	static void verifyFixFilePerms(boolean overrideVerification)
+	{
+		// libs are only loaded on OSType.Windows so skip checking for OSType
+		if (!nativesLoaded)
+		{
+			log.debug("Launcher natives were not loaded. Skipping filesystem permission verification.");
+			return;
+		}
+
+		log.info("Launcher is running with elevated permissions: " + isRunningElevated());
+		log.info("Launcher is Jagex Launcher child: " + isJagexLauncherChild());
+		if (overrideVerification)
+		{
+			log.info("Exception caught. Overriding filesystem permission verification to engage fixFilePerms().");
+		}
+
+		switch (filePermsStep)
+		{
+			case REGULAR_VERIFICATION:
+			case REGULAR_VERIFICATION_JAGEX_LAUNCHER:
+				regularVerification(overrideVerification);
+				break;
+			case FIX_USER:
+			case FIX_USER_JAGEX_LAUNCHER:
+				fixFilePerms(false);
+				break;
+			case VERIFY_POST_USER:
+			case VERIFY_POST_USER_JAGEX_LAUNCHER:
+				postUserFixVerification();
+				break;
+			case FIX_EVERYONE:
+			case FIX_EVERYONE_JAGEX_LAUNCHER:
+				fixFilePerms(true);
+				break;
+			case VERIFY_POST_EVERYONE:
+			case VERIFY_POST_EVERYONE_JAGEX_LAUNCHER:
+				postEveryoneFixVerification();
+				break;
+		}
+	}
+
+	private static boolean isRunningElevated()
+	{
+		return isRunningElevated(ProcessHandle.current().pid());
+	}
+
+	private static native boolean isRunningElevated(long pid);
+
+	private static boolean isJagexLauncherChild()
+	{
+		// alternatively get the children or descendants of JagexLauncher.exe
+		ProcessHandle parent = ProcessHandle.current().parent().orElse(null);
+		if (parent != null)
+		{
+			return parent.info().command().orElse("-").contains("JagexLauncher.exe");
+		}
+		return false;
+	}
+
+	private static void regularVerification(boolean overrideVerification)
+	{
+		if (failedFilePermsVerification() || overrideVerification)
+		{
+			if (isJagexLauncherChild())
+			{
+				filePermsStep = FilePermsStep.REGULAR_VERIFICATION_JAGEX_LAUNCHER;
+			}
+			log.warn("Filesystem permissions verification failed. Requesting elevated permissions to correct permissions.");
+			requestElevation("Would you like to close all RuneLite instances and restart with elevated permissions to correct these issues?");
+		}
+		else
+		{
+			log.info("Filesystem permissions verification has succeeded.");
+		}
+	}
+
+	private static boolean failedFilePermsVerification()
+	{
+		return comboFailedFilePermsVerification(RUNELITE_DIR)
+			|| comboFailedFilePermsVerification(LOGS_DIR)
+			|| comboFailedFilePermsVerification(REPO_DIR)
+			|| comboFailedFilePermsVerification(PROFILES_DIR);
+	}
+
+	private static boolean comboFailedFilePermsVerification(File dir)
+	{
+		return dirFailedFilePermsVerification(dir) || fileFailedFilePermsVerification(dir);
+	}
+
+	private static boolean dirFailedFilePermsVerification(File dir)
+	{
+		if (!dir.exists() && !dir.mkdirs())
+		{
+			log.warn("Filesystem permissions verification: unable to create directory " + dir.getAbsolutePath());
+		}
+		Path path = dir.toPath();
+		// File::canRead/canWrite/canExecute only check the file attributes, not the ACL (the error fixed by icacls).
+		// Files::isReadable/isWritable/isExecutable do properly check the file attributes and the ACL.
+		if (!Files.isReadable(path) || !Files.isWritable(path) || !Files.isExecutable(path))
+		{
+			log.warn("Filesystem permissions verification: verification failed for directory " + dir.getAbsolutePath());
+			return true;
+		}
+		return false;
+	}
+
+	private static boolean fileFailedFilePermsVerification(File dir)
+	{
+		boolean result = false;
+		File testFile = new File(dir, "FilePermsVerification");
+		Path path = testFile.toPath();
+		try
+		{
+			Files.createFile(path);
+		}
+		catch (IOException ex)
+		{
+			log.error("Filesystem permissions verification: unable to create test file " + testFile.getAbsolutePath(), ex);
+			// Files::isWritable also returns false if the file does not exist; no need to return here
+		}
+		// File::canRead/canWrite/canExecute only check the file attributes, not the ACL (the error fixed by icacls).
+		// Files::isReadable/isWritable/isExecutable do properly check the file attributes and the ACL.
+		if (!Files.isReadable(path) || !Files.isWritable(path) || !Files.isExecutable(path))
+		{
+			log.warn("Filesystem permissions verification: verification failed for file " + testFile.getAbsolutePath());
+			result = true;
+		}
+		try
+		{
+			Files.deleteIfExists(path);
+		}
+		catch (IOException ignored)
+		{
+			// it is not problematic if the file is not deleted
+		}
+		return result;
+	}
+
+	private static void requestElevation(String messageAddition)
+	{
+		try (var in = FilePermissionManager.class.getResourceAsStream("runelite_128.png"))
+		{
+			assert in != null;
+			ImageIcon icon = new ImageIcon(ImageIO.read(in));
+			icon = new ImageIcon(icon.getImage().getScaledInstance(64, 64, java.awt.Image.SCALE_SMOOTH));
+			UIManager.put("OptionPane.background", DARKER_GRAY_COLOR);
+			UIManager.put("Panel.background", DARKER_GRAY_COLOR);
+			UIManager.put("OptionPane.messageForeground", Color.WHITE);
+			UIManager.put("OptionPane.sameSizeButtons", true);
+			UIManager.put("OptionPane.okButtonText", "Restart");
+			String title = "RuneLite - Filesystem permission problems detected";
+			String message = "RuneLite has detected filesystem permission problems.\n" + messageAddition;
+
+			final int result = JOptionPane.showConfirmDialog(null,
+				message,
+				title,
+				JOptionPane.OK_CANCEL_OPTION,
+				JOptionPane.WARNING_MESSAGE,
+				icon);
+
+			if (result == JOptionPane.OK_OPTION)
+			{
+				terminateProcesses();
+				elevateLauncher(fixArgs());
+			}
+		}
+		catch (Exception ex)
+		{
+			log.error("Elevation request: error showing JOptionPane.", ex);
+			terminateProcesses();
+			elevateLauncher(fixArgs());
+		}
+	}
+
+	private static void terminateProcesses()
+	{
+		// terminate all other RuneLite.exe processes
+		String path = ProcessHandle.current().info().command().orElse(null);
+
+		if (path == null)
+		{
+			log.debug("Aborting termination of other RuneLite processes. Launcher path is null.");
+			return;
+		}
+
+		long pidCurrent = ProcessHandle.current().pid();
+		Set<ProcessHandle> toTerminate = ProcessHandle.allProcesses()
+			.filter(processHandle ->
+				processHandle.info().command().orElse("-").equals(path)
+					&& processHandle.pid() != pidCurrent
+					&& processHandle.isAlive())
+			.collect(Collectors.toSet());
+		for (ProcessHandle processHandle : toTerminate)
+		{
+			processHandle.destroyForcibly();
+			try
+			{
+				// wait for the process to terminate
+				processHandle.onExit().get();
+			}
+			catch (Exception ignored)
+			{
+			}
+		}
+		log.debug("Terminated other RuneLite.exe processes.");
+	}
+
+	private static void elevateLauncher(String args)
+	{
+		elevateOrUnelevateLauncher(true, args);
+	}
+
+	private static void elevateOrUnelevateLauncher(boolean elevate, String args)
+	{
+		String name = elevate ? "elevation" : "unelevation";
+		if (!nativesLoaded)
+		{
+			log.debug("Aborting " + name + " request. Launcher natives were not loaded.");
+			return;
+		}
+
+		String launcherPath = ProcessHandle.current().info().command().orElse(null);
+		if (launcherPath == null)
+		{
+			log.debug("Aborting " + name + " request. launcherPath is null");
+			return;
+		}
+
+		// either replace \ with \\ or with /
+		launcherPath = launcherPath.replace("\\", "/");
+		if (elevate)
+		{
+			// if already running with elevated permissions, no UAC prompt will be shown but the launcher will be
+			// relaunched with the requested args (and elevated permissions)
+			elevate(launcherPath, args);
+		}
+		else
+		{
+			unelevate(launcherPath, args);
+		}
+		log.debug("Executing " + name + " request");
+		System.exit(0);
+	}
+
+	private static native void elevate(String launcherPath, String args);
+
+	private static native void unelevate(String launcherPath, String args);
+
+	private static String fixArgs()
+	{
+		return "--fixfileperms=" + FilePermsStep.increaseStep(filePermsStep);
+	}
+
+	private static void fixFilePerms(boolean forceEveryone)
+	{
+		if (!isRunningElevated())
+		{
+			// icacls should only be called with elevated permissions; without those, permissions might get fixed for
+			// some files but not for others. This results in a dangerous scenario in which the permission verification
+			// succeeds but the permissions are still incorrect.
+			log.info("Launcher is not running with elevated permissions. Skipping filesystem permission correction.");
+			return;
+		}
+
+		if (!RUNELITE_DIR.exists() && !RUNELITE_DIR.mkdirs())
+		{
+			SwingUtilities.invokeLater(() -> new FatalErrorDialog("Unable to create RuneLite directory " + RUNELITE_DIR.getAbsolutePath()
+				+ " while running with elevated permissions. Check if your filesystem permissions are correct.").open());
+			return;
+		}
+
+		String sid = ProcessHandle.current().info().user().orElse(null);
+		if (sid == null || forceEveryone)
+		{
+			sid = "*S-1-1-0";
+			// use SID for "Everyone" (compatible with different system languages) if user is not returned
+			// or as fallback when setting permissions with the current user is not successful
+			// see https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
+			// and https://system32.eventsentry.com/codes/field/Well-known%20Security%20Identifiers%20(SIDs) for more info
+		}
+		// set normal permissions
+		runicaclsCmd("*S-1-5-18"); // NT AUTHORITY\SYSTEM
+		runicaclsCmd("*S-1-5-32-544"); // BUILTIN\Administrators
+		runicaclsCmd(sid); // current user or everyone
+
+		String dir = "\"" + RUNELITE_DIR.getAbsolutePath() + "\\*.*\"";
+		List<String> attribCommands = new ArrayList<>(Arrays.asList("attrib", "-r", "-a", "-s", dir, "/d", "/s"));
+		runCmd(attribCommands);
+
+		log.info("Filesystem permissions correction completed for i.a. SID " + sid + " Restarting without elevated permissions to verify.");
+		terminateProcesses();
+		unelevateLauncher(fixArgs());
+	}
+
+	private static void runicaclsCmd(String sid)
+	{
+		String dir = "\"" + RUNELITE_DIR.getAbsolutePath() + "\"";
+		sid = sid + ":F";
+		List<String> icaclsCommands = new ArrayList<>(Arrays.asList("icacls", dir, "/grant:r", sid, "/inheritance:r", "/t", "/c"));
+		runCmd(icaclsCommands);
+	}
+
+	private static void runCmd(List<String> commands)
+	{
+		String cmdName = commands.get(0);
+		List<String> tokens = new ArrayList<>(Arrays.asList("cmd.exe", "/c"));
+		tokens.addAll(commands);
+		log.info(cmdName + " ProcessBuilder tokens: " + tokens);
+		ProcessBuilder cmdPB = new ProcessBuilder(tokens);
+		try
+		{
+			Process cmdProcess = cmdPB.start();
+			BufferedReader br = new BufferedReader(new InputStreamReader(cmdProcess.getInputStream()));
+			String line;
+			log.info(cmdName + " output:");
+			while ((line = br.readLine()) != null)
+			{
+				if (!line.isEmpty())
+				{
+					log.info(line);
+				}
+			}
+			try
+			{
+				log.debug(cmdName + " exit value is " + cmdProcess.waitFor());
+			}
+			catch (InterruptedException ex)
+			{
+				log.debug(cmdName + " interrupted", ex);
+			}
+		}
+		catch (IOException ex)
+		{
+			log.error("IOException " + cmdName, ex);
+		}
+	}
+
+	private static void unelevateLauncher(String args)
+	{
+		elevateOrUnelevateLauncher(false, args);
+	}
+
+	private static void postUserFixVerification()
+	{
+		if (failedFilePermsVerification())
+		{
+			log.warn("Filesystem permissions correction failed. Requesting elevated permissions to attempt correction with 'Everyone' SID.");
+			requestElevation("Would you like to close all RuneLite instances and restart with elevated permissions to attempt a final correction?");
+		}
+		else
+		{
+			log.info("Filesystem permissions corrected successfully.");
+			// if not using the Jagex Launcher, RL will load and the user can log in
+			if (isJagexLauncherStep())
+			{
+				suggestJagexLauncher();
+			}
+		}
+	}
+
+	private static boolean isJagexLauncherStep()
+	{
+		return filePermsStep.getStep() >= FilePermsStep.REGULAR_VERIFICATION_JAGEX_LAUNCHER.getStep();
+	}
+
+	private static void suggestJagexLauncher()
+	{
+		okOptionPane("Filesystem permissions corrected successfully",
+			"The filesystem permission problems were corrected successfully.\n"
+				+ "Please relaunch RuneLite via the Jagex Launcher.",
+			true);
+	}
+
+	private static void okOptionPane(String titleAdditions, String message, boolean jagexLauncherSuggestions)
+	{
+		try (var in = FilePermissionManager.class.getResourceAsStream("runelite_128.png"))
+		{
+			assert in != null;
+			ImageIcon icon = new ImageIcon(ImageIO.read(in));
+			icon = new ImageIcon(icon.getImage().getScaledInstance(64, 64, java.awt.Image.SCALE_SMOOTH));
+			UIManager.put("OptionPane.background", DARKER_GRAY_COLOR);
+			UIManager.put("Panel.background", DARKER_GRAY_COLOR);
+			UIManager.put("OptionPane.messageForeground", Color.WHITE);
+			String title = titleAdditions.isEmpty() ? "RuneLite" : "RuneLite - " + titleAdditions;
+
+			String[] options = {"Ok"};
+			JOptionPane.showOptionDialog(null,
+				message,
+				title,
+				JOptionPane.DEFAULT_OPTION,
+				JOptionPane.INFORMATION_MESSAGE,
+				icon,
+				options,
+				null);
+		}
+		catch (Exception ex)
+		{
+			String name = jagexLauncherSuggestions ? "Jagex Launcher suggestion" : "Final correction attempt failed";
+			log.debug(name + ": error showing JOptionPane.", ex);
+		}
+		if (jagexLauncherSuggestions)
+		{
+			System.exit(0);
+		}
+	}
+
+	private static void postEveryoneFixVerification()
+	{
+		if (failedFilePermsVerification())
+		{
+			log.warn("Filesystem permissions correction failed with 'Everyone' SID. No further attempts will be made during this session.");
+			logFilePerms();
+			if (isJagexLauncherStep())
+			{
+				okOptionPane("Filesystem permission problems detected",
+					"Filesystem permissions correction failed.\n"
+						+ "Please relaunch RuneLite via the Jagex Launcher.",
+					true);
+			}
+			else
+			{
+				okOptionPane("Filesystem permission problems detected",
+					"Filesystem permissions correction failed.\n" +
+						"No further attempts will be made during this session.",
+					false);
+			}
+		}
+		else
+		{
+			log.info("Filesystem permissions corrected successfully.");
+			// if not using the Jagex Launcher, RL will load and the user can log in
+			if (isJagexLauncherStep())
+			{
+				suggestJagexLauncher();
+			}
+		}
+	}
+
+	private static void logFilePerms()
+	{
+		// log file perms using icacls to more easily provide support to the user in case the fixes fail
+		log.info("icacls filesystem permissions for support purposes:");
+		icaclsLogCmd(RUNELITE_DIR);
+		icaclsLogCmd(LOGS_DIR);
+		icaclsLogCmd(REPO_DIR);
+		icaclsLogCmd(PROFILES_DIR);
+	}
+
+	private static void icaclsLogCmd(File directory)
+	{
+		String dir = "\"" + directory.getAbsolutePath() + "\"";
+		List<String> icaclsCommands = new ArrayList<>(Arrays.asList("icacls", dir));
+		runCmd(icaclsCommands);
+	}
+}

--- a/src/main/java/net/runelite/launcher/FilePermsStep.java
+++ b/src/main/java/net/runelite/launcher/FilePermsStep.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, YvesW <https://github.com/YvesW>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.launcher;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum FilePermsStep
+{
+	REGULAR_VERIFICATION(0),
+	FIX_USER(1),
+	VERIFY_POST_USER(2),
+	FIX_EVERYONE(3),
+	VERIFY_POST_EVERYONE(4),
+	// >= 10 is the same as 0-9 but the launcher was initially launched by the Jagex Launcher
+	REGULAR_VERIFICATION_JAGEX_LAUNCHER(10),
+	FIX_USER_JAGEX_LAUNCHER(11),
+	VERIFY_POST_USER_JAGEX_LAUNCHER(12),
+	FIX_EVERYONE_JAGEX_LAUNCHER(13),
+	VERIFY_POST_EVERYONE_JAGEX_LAUNCHER(14);
+
+	private final int step;
+
+	private boolean compare(int i)
+	{
+		return step == i;
+	}
+
+	private static FilePermsStep getValue(int step)
+	{
+		for (FilePermsStep filePermsStep : FilePermsStep.values())
+		{
+			if (filePermsStep.compare(step))
+			{
+				return filePermsStep;
+			}
+		}
+		return FilePermsStep.REGULAR_VERIFICATION;
+	}
+
+	static FilePermsStep increaseStep(FilePermsStep filePermsStep)
+	{
+		return getValue(filePermsStep.getStep() + 1);
+	}
+}


### PR DESCRIPTION
Aims to reduce support traffic and improve user experience by:
1. detecting and fixing filesystem permission (ACL/ACE related) and attribute (e.g. read only) problems, and
~~2. detecting and fixing login problems when the user launches RL with elevated permissions via a Jagex Launcher instance that's not running with elevated permissions~~ Edit: dropped 2 and PRed again separately as requested.

Please do test these changes by breaking your permissions in a VM. In my testing, I broke my Windows user profile before I could break RL, but there are only so many way to break your file system that I could think of.

Regarding testing I recommend at least trying the following steps:
**WARNING: THIS TESTING PROCEDURE MIGHT BREAK YOUR USERPROFILE ON THE VM AFTER REBOOTING**
1. Create a fresh windows VM
2. Create a new local user with admin rights so it's nbd if it gets bricked
3. Install the updated launcher
4. Set ``.runelite`` to read only
5. To remove all permissions for your user account for .runelite and even all permissions for the subdirectory & files:
```
icacls "%userprofile%\.runelite" /remove vmComputerNameHere\vmAccountNameHere /inheritance:r /t /c
```
6. To remove permissions for your user account for %userprofile%:
```
icacls "%userprofile%" /remove DESKTOP-QSUTV7K\LauncherTest2 /c
```
7. Start RL & follow the on-screen instructions
8. Success/failure
9. Afterwards you could try running the following commands to try to prevent bricking your userprofile:
```
icacls "%userprofile%" /grant:r vmComputerNameHere\vmAccountNameHere :F /inheritance:r /t /c
icacls "%userprofile%" /grant:r *S-1-5-18:F /inheritance:r /t /c
icacls "%userprofile%" /grant:r *S-1-5-32-544:F /inheritance:r /t /c
```